### PR TITLE
JBPM-6798: Stunner & Forms - Field updates are not fired when selecting a canvas shape

### DIFF
--- a/src/main/java/com/ait/lienzo/client/widget/LienzoHandlerManager.java
+++ b/src/main/java/com/ait/lienzo/client/widget/LienzoHandlerManager.java
@@ -193,8 +193,6 @@ final class LienzoHandlerManager
                 m_mouse_button_middle = (event.getNativeButton() == NativeEvent.BUTTON_MIDDLE);
                 m_mouse_button_right = (event.getNativeButton() == NativeEvent.BUTTON_RIGHT);
 
-                event.preventDefault();
-
                 m_viewport.getOnEventHandlers().getOnMouseClickEventHandle().onMouseEventAfter(event);
             }
         });
@@ -306,8 +304,6 @@ final class LienzoHandlerManager
                 m_mouse_button_right = (event.getNativeButton() == NativeEvent.BUTTON_RIGHT);
 
                 onNodeMouseDown(nevent);
-
-                event.preventDefault();
 
                 m_viewport.getOnEventHandlers().getOnMouseDownEventHandle().onMouseEventBefore(event);
             }


### PR DESCRIPTION
@romartin @hasys could you please review?

Fix issue on Lienzo that prevents the default behaviour of the native event. That was making some weird behaviour synchronizing the forms & the model.

This is part of an ensemble merge with:
https://github.com/kiegroup/lienzo-core/pull/7
https://github.com/kiegroup/kie-wb-common/pull/1419