### PR TITLE
Disable select action for Middle and Right mouse buttons

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/SelectionManager.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/SelectionManager.java
@@ -174,6 +174,11 @@ public class SelectionManager implements NodeMouseDoubleClickHandler, NodeMouseC
                                          wiresManager);
     }
 
+    protected boolean isSelectionCreationInProcess()
+    {
+        return m_selectionCreationInProcess;
+    }
+
     public void setSelectionShapeProvider(SelectionShapeProvider m_selectionShapeProvider) {
         this.m_selectionShapeProvider = m_selectionShapeProvider;
     }
@@ -394,6 +399,10 @@ public class SelectionManager implements NodeMouseDoubleClickHandler, NodeMouseC
 
     @Override public void onNodeMouseDown(NodeMouseDownEvent event)
     {
+        if (!event.isButtonLeft()) {
+            return;
+        }
+
         Node<?> node = m_layer.getViewport().findShapeAtPoint(event.getX(), event.getY());
         if (node == null)
         {
@@ -405,7 +414,6 @@ public class SelectionManager implements NodeMouseDoubleClickHandler, NodeMouseC
             destroySelectionShape();
             m_layer.draw();
         }
-
     }
 
     public void clearSelection() {


### PR DESCRIPTION
Hi @romartin @manstis 

Now it is possible to start selection by Middle and Right mouse buttons, but not possible to select elements. I guess we should disable middle and right buttons for selection at all.