### PR TITLE
JBPM-6110 Splitting Context2D save/restore to support container

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/Context2D.java
+++ b/src/main/java/com/ait/lienzo/client/core/Context2D.java
@@ -59,11 +59,31 @@ public class Context2D
         return m_jso;
     }
 
+    /**
+     * Save and push a new container context to the stack
+     */
+    public void saveContainer(){
+        m_jso.saveContainer();
+    }
+
+    /**
+     * Restore and pop the current container context from the stack returning to the previous context
+     */
+    public void restoreContainer(){
+        m_jso.restoreContainer();
+    }
+
+    /**
+     * Saves the current context state (i.e style, fill, stroke...) pushing to the stack
+     */
     public void save()
     {
         m_jso.save();
     }
 
+    /**
+     * Restore the saved context state (i.e style, fill, stroke...) by popping from the stack
+     */
     public void restore()
     {
         m_jso.restore();

--- a/src/main/java/com/ait/lienzo/client/core/NativeContext2D.java
+++ b/src/main/java/com/ait/lienzo/client/core/NativeContext2D.java
@@ -125,6 +125,14 @@ public final class NativeContext2D extends JavaScriptObject
 		return this;
     }-*/;
 
+    public final void saveContainer() {
+        this.save();
+    }
+
+    public final void restoreContainer() {
+        this.restore();
+    }
+
     public final native void save()
     /*-{
 		this.save();

--- a/src/main/java/com/ait/lienzo/client/core/shape/Node.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/Node.java
@@ -100,7 +100,6 @@ import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONValue;
-import com.google.gwt.touch.client.Point;
 
 /**
  * Node is the base class for {@link ContainerNode} and {@link Shape}.
@@ -487,7 +486,7 @@ public abstract class Node<T extends Node<T>> implements IDrawable<T>
         }
         if (context.isDrag() || isVisible())
         {
-            context.save();
+            context.saveContainer();
 
             final Transform xfrm = getPossibleNodeTransform();
 
@@ -497,7 +496,7 @@ public abstract class Node<T extends Node<T>> implements IDrawable<T>
             }
             drawWithoutTransforms(context, alpha, bounds);
 
-            context.restore();
+            context.restoreContainer();
         }
     }
 


### PR DESCRIPTION
When implementing the canvas to SVG export, it was noticed on the `Context2D` that we should be able to identify whether a container was supposed to be created /saved and when the container was closed/restored from other save/restore operations.
Distinguishing the save/restore of container nodes from other save/restore operations regarding fill, stroke, path, etc, is important when exporting the canvas to SVG and brings a more semantic and flexibility approach.
The default implementation on the `NativeContext2D` keeps the native canvas context behavior calling save/restore only, no effects when working with native canvas.

@romartin 
@mdproctor 