### PR TITLE
JBPM-6110 Refactor to support injecting a INativeContext2D for SVG export

### DIFF
--- a/src/main/java/com/ait/lienzo/Lienzo.gwt.xml
+++ b/src/main/java/com/ait/lienzo/Lienzo.gwt.xml
@@ -24,4 +24,5 @@
 	<entry-point class='com.ait.lienzo.client.core.config.LienzoCoreEntryPoint' />
 	<source path='client' />
 	<source path='shared' />
+
 </module>

--- a/src/main/java/com/ait/lienzo/client/core/Context2D.java
+++ b/src/main/java/com/ait/lienzo/client/core/Context2D.java
@@ -42,21 +42,31 @@ import com.google.gwt.dom.client.Element;
  */
 public class Context2D
 {
-    private final NativeContext2D m_jso;
+    private final INativeContext2D m_jso;
 
     public Context2D(final CanvasElement element)
     {
         this(NativeContext2D.make(element));
     }
 
-    public Context2D(final NativeContext2D jso)
+    public Context2D(final INativeContext2D jso)
     {
         m_jso = jso;
     }
 
-    public NativeContext2D getNativeContext()
+    public INativeContext2D getNativeContext()
     {
         return m_jso;
+    }
+
+
+    public void saveGroup(){
+        m_jso.saveGroup();
+    }
+
+
+    public void restoreGroup(){
+        m_jso.restoreGroup();
     }
 
     public void save()

--- a/src/main/java/com/ait/lienzo/client/core/INativeContext2D.java
+++ b/src/main/java/com/ait/lienzo/client/core/INativeContext2D.java
@@ -1,0 +1,542 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ait.lienzo.client.core;
+
+import com.ait.lienzo.client.core.types.ImageData;
+import com.ait.lienzo.client.core.types.LinearGradient;
+import com.ait.lienzo.client.core.types.PathPartList;
+import com.ait.lienzo.client.core.types.PatternGradient;
+import com.ait.lienzo.client.core.types.RadialGradient;
+import com.ait.lienzo.client.core.types.Shadow;
+import com.ait.lienzo.client.core.types.TextMetrics;
+import com.ait.lienzo.client.core.types.Transform;
+import com.ait.tooling.nativetools.client.collection.NFastDoubleArrayJSO;
+import com.google.gwt.dom.client.Element;
+
+public interface INativeContext2D {
+
+    void initDeviceRatio();
+
+    void saveGroup();
+
+    void restoreGroup();
+
+    void save()
+    /*-{
+		this.save();
+    }-*/;
+
+    void restore()
+    /*-{
+		this.restore();
+    }-*/;
+
+    void beginPath()
+    /*-{
+		this.beginPath();
+    }-*/;
+
+    void closePath()
+    /*-{
+		this.closePath();
+    }-*/;
+
+    void moveTo(double x, double y)
+    /*-{
+		this.moveTo(x, y);
+    }-*/;
+
+    void lineTo(double x, double y)
+    /*-{
+		this.lineTo(x, y);
+    }-*/;
+
+    void setGlobalCompositeOperation(String operation)
+    /*-{
+		this.globalCompositeOperation = operation || "source-over";
+    }-*/;
+
+    void setLineCap(String lineCap)
+    /*-{
+		this.lineCap = lineCap || "butt";
+    }-*/;
+
+    void setLineJoin(String lineJoin)
+    /*-{
+		this.lineJoin = lineJoin || "miter";
+    }-*/;
+
+    void quadraticCurveTo(double cpx, double cpy, double x, double y)
+    /*-{
+		this.quadraticCurveTo(cpx, cpy, x, y);
+    }-*/;
+
+    void arc(double x, double y, double radius, double startAngle, double endAngle)
+    /*-{
+		this.arc(x, y, radius, startAngle, endAngle, false);
+    }-*/;
+
+    void arc(double x, double y, double radius, double startAngle, double endAngle, boolean antiClockwise)
+    /*-{
+		this.arc(x, y, radius, startAngle, endAngle, antiClockwise);
+    }-*/;
+
+    void ellipse(double x, double y, double rx, double ry, double ro, double sa, double ea, boolean ac)
+    /*-{
+		this.ellipse(x, y, rx, ry, ro, sa, ea, ac);
+    }-*/;
+
+    void ellipse(double x, double y, double rx, double ry, double ro, double sa, double ea)
+    /*-{
+		this.ellipse(x, y, rx, ry, ro, sa, ea, false);
+    }-*/;
+
+    void arcTo(double x1, double y1, double x2, double y2, double radius)
+    /*-{
+		this.arcTo(x1, y1, x2, y2, radius);
+    }-*/;
+
+    void bezierCurveTo(double cp1x, double cp1y, double cp2x, double cp2y, double x, double y)
+    /*-{
+		this.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, x, y);
+    }-*/;
+
+    void clearRect(double x, double y, double w, double h)
+    /*-{
+		if ((w <= 0) || (h <= 0)) {
+			return;
+		}
+		this.clearRect(x, y, w, h);
+    }-*/;
+
+    void clip()
+    /*-{
+		this.clip();
+    }-*/;
+
+    void fill()
+    /*-{
+		this.fill();
+    }-*/;
+
+    void stroke()
+    /*-{
+		this.stroke();
+    }-*/;
+
+    void fillRect(double x, double y, double w, double h)
+    /*-{
+		if ((w <= 0) || (h <= 0)) {
+			return;
+		}
+		this.fillRect(x, y, w, h);
+    }-*/;
+
+    void fillText(String text, double x, double y)
+    /*-{
+		this.fillText(text, x, y);
+    }-*/;
+
+    void fillTextWithGradient(String text, double x, double y, double sx, double sy, double ex, double ey, String color)
+    /*-{
+        var grad = this.createLinearGradient(sx, sy, ex, ey);
+
+        grad.addColorStop(0, color);
+
+        grad.addColorStop(1, color);
+
+        this.fillStyle = grad;
+
+        this.fillText(text, x, y);
+    }-*/;
+
+    void fillText(String text, double x, double y, double maxWidth)
+    /*-{
+		this.fillText(text, x, y, maxWidth);
+    }-*/;
+
+    void setFillColor(String fill)
+    /*-{
+		this.fillStyle = fill;
+    }-*/;
+
+    void rect(double x, double y, double w, double h)
+    /*-{
+		if ((w <= 0) || (h <= 0)) {
+			return;
+		}
+		this.rect(x, y, w, h);
+    }-*/;
+
+    void rotate(double angle)
+    /*-{
+		this.rotate(angle);
+    }-*/;
+
+    void scale(double sx, double sy)
+    /*-{
+		this.scale(sx*scalingRatio, sy*scalingRatio);
+    }-*/;
+
+    void setStrokeColor(String color)
+    /*-{
+		this.strokeStyle = color;
+    }-*/;
+
+    void setStrokeWidth(double width)
+    /*-{
+		this.lineWidth = width;
+    }-*/;
+
+    void setImageSmoothingEnabled(boolean enabled)
+    /*-{
+		this.imageSmoothingEnabled = enabled;
+    }-*/;
+
+    void setFillGradient(LinearGradient.LinearGradientJSO grad)
+    /*-{
+		if (grad) {
+			var that = this.createLinearGradient(grad.start.x, grad.start.y,
+					grad.end.x, grad.end.y);
+
+			var list = grad.colorStops;
+
+			for (i = 0; i < list.length; i++) {
+				that.addColorStop(list[i].stop, list[i].color);
+			}
+			this.fillStyle = that;
+		} else {
+			this.fillStyle = null;
+		}
+    }-*/;
+
+    void setFillGradient(PatternGradient.PatternGradientJSO grad)
+    /*-{
+		if ((grad) && ((typeof grad.image) === 'function')) {
+			var elem = grad.image();
+			if (elem) {
+				this.fillStyle = this.createPattern(elem, grad.repeat);
+			} else {
+				this.fillStyle = null;
+			}
+		} else {
+			this.fillStyle = null;
+		}
+    }-*/;
+
+    void setFillGradient(RadialGradient.RadialGradientJSO grad)
+    /*-{
+		if (grad) {
+			var that = this.createRadialGradient(grad.start.x, grad.start.y,
+					grad.start.radius, grad.end.x, grad.end.y, grad.end.radius);
+
+			var list = grad.colorStops;
+
+			for (i = 0; i < list.length; i++) {
+				that.addColorStop(list[i].stop, list[i].color);
+			}
+			this.fillStyle = that;
+		} else {
+			this.fillStyle = null;
+		}
+    }-*/;
+
+    void transform(Transform.TransformJSO jso)
+    /*-{
+		if (jso) {
+			this.transform(jso[0], jso[1], jso[2], jso[3], jso[4], jso[5]);
+		}
+    }-*/;
+
+    void transform(double d0, double d1, double d2, double d3, double d4, double d5)
+    /*-{
+		this.transform(d0, d1, d2, d3, d4, d5);
+    }-*/;
+
+    void setTransform(Transform.TransformJSO jso)
+    /*-{
+		if (jso) {
+			this.setTransform(jso[0], jso[1], jso[2], jso[3], jso[4], jso[5]);
+		}
+    }-*/;
+
+    void setTransform(double d0, double d1, double d2, double d3, double d4, double d5)
+    /*-{
+		this.setTransform(d0, d1, d2, d3, d4, d5);
+    }-*/;
+
+    void setToIdentityTransform()
+    /*-{
+		this.setTransform(1, 0, 0, 1, 0, 0);
+    }-*/;
+
+    void setTextFont(String font)
+    /*-{
+		this.font = font;
+    }-*/;
+
+    void setTextBaseline(String baseline)
+    /*-{
+		this.textBaseline = baseline || "alphabetic";
+    }-*/;
+
+    void setTextAlign(String align)
+    /*-{
+		this.textAlign = align || "start";
+    }-*/;
+
+    void strokeText(String text, double x, double y)
+    /*-{
+		this.strokeText(text, x, y);
+    }-*/;
+
+    void setGlobalAlpha(double alpha)
+    /*-{
+		this.globalAlpha = alpha;
+    }-*/;
+
+    void translate(double x, double y)
+    /*-{
+		this.translate(x, y);
+    }-*/;
+
+    void setShadow(Shadow.ShadowJSO shadow)
+    /*-{
+		if (shadow) {
+			this.shadowColor = shadow.color;
+			this.shadowOffsetX = shadow.offset.x;
+			this.shadowOffsetY = shadow.offset.y;
+			this.shadowBlur = shadow.blur;
+		} else {
+			this.shadowColor = "transparent";
+			this.shadowOffsetX = 0;
+			this.shadowOffsetY = 0;
+			this.shadowBlur = 0;
+		}
+    }-*/;
+
+    boolean isSupported(String feature)
+    /*-{
+		return (this[feature] !== undefined);
+    }-*/;
+
+    boolean isPointInPath(double x, double y)
+    /*-{
+		return this.isPointInPath(x, y);
+    }-*/;
+
+    ImageData getImageData(double x, double y, double width, double height)
+    /*-{
+		return this.getImageData(x, y, width, height);
+    }-*/;
+
+    ImageData createImageData(double width, double height)
+    /*-{
+		return this.createImageData(width, height);
+    }-*/;
+
+    ImageData createImageData(ImageData data)
+    /*-{
+		return this.createImageData(data);
+    }-*/;
+
+    void putImageData(ImageData imageData, double x, double y)
+    /*-{
+		this.putImageData(imageData, x, y);
+    }-*/;
+
+    void putImageData(ImageData imageData, double x, double y, double dx, double dy, double dw, double dh)
+    /*-{
+		if ((dw <= 0) || (dh <= 0)) {
+			return;
+		}
+		this.putImageData(imageData, x, y, dx, dy, dw, dh);
+    }-*/;
+
+    TextMetrics measureText(String text)
+    /*-{
+		return this.measureText(text);
+    }-*/;
+
+    void drawImage(Element image, double x, double y)
+    /*-{
+		this.drawImage(image, x, y);
+    }-*/;
+
+    void drawImage(Element image, double x, double y, double w, double h)
+    /*-{
+		if ((w <= 0) || (h <= 0)) {
+			return;
+		}
+		this.drawImage(image, x, y, w, h);
+    }-*/;
+
+    void drawImage(Element image, double sx, double sy, double sw, double sh, double x, double y, double w, double h)
+    /*-{
+		if ((w <= 0) || (h <= 0)) {
+			return;
+		}
+		if ((sw <= 0) || (sh <= 0)) {
+			return;
+		}
+		this.drawImage(image, sx, sy, sw, sh, x, y, w, h);
+    }-*/;
+
+    void resetClip()
+    /*-{
+		this.resetClip();
+    }-*/;
+
+    void setMiterLimit(double limit)
+    /*-{
+		this.miterLimit = limit;
+    }-*/;
+
+    void setLineDash(NFastDoubleArrayJSO dashes)
+    /*-{
+		this.setLineDash(dashes || []);
+    }-*/;
+
+    void setLineDashOffset(double offset)
+    /*-{
+		this.setLineDashOffset(offset);
+    }-*/;
+
+    double getBackingStorePixelRatio()
+    /*-{
+		return this.backingStorePixelRatio || 1;
+    }-*/;
+
+    boolean path(PathPartList.PathPartListJSO list)
+    /*-{
+		if (!list) {
+			return false;
+		}
+		var leng = list.length;
+		if (leng < 1) {
+			return false;
+		}
+		var indx = 0;
+		var fill = false;
+		this.beginPath();
+		while (indx < leng) {
+			var e = list[indx++];
+			var p = e.points;
+			switch (e.command) {
+			case 1:
+				this.lineTo(p[0], p[1]);
+				break;
+			case 2:
+				this.moveTo(p[0], p[1]);
+				break;
+			case 3:
+				this.bezierCurveTo(p[0], p[1], p[2], p[3], p[4], p[5]);
+				break;
+			case 4:
+				this.quadraticCurveTo(p[0], p[1], p[2], p[3]);
+				break;
+			case 5:
+				this.ellipse(p[0], p[1], p[2], p[3], p[6], p[4], p[4] + p[5],
+						(1 - p[7]) > 0);
+				break;
+			case 6:
+				this.closePath();
+				fill = true;
+				break;
+			case 7:
+				this.arcTo(p[0], p[1], p[2], p[3], p[4]);
+				break;
+			}
+		}
+		return fill;
+    }-*/;
+
+    boolean clip(PathPartList.PathPartListJSO list)
+    /*-{
+		if (!list) {
+			return false;
+		}
+		var leng = list.length;
+		if (leng < 1) {
+			return false;
+		}
+		var indx = 0;
+		var fill = false;
+		while (indx < leng) {
+			var e = list[indx++];
+			var p = e.points;
+			switch (e.command) {
+			case 1:
+				this.lineTo(p[0], p[1]);
+				break;
+			case 2:
+				this.moveTo(p[0], p[1]);
+				break;
+			case 3:
+				this.bezierCurveTo(p[0], p[1], p[2], p[3], p[4], p[5]);
+				break;
+			case 4:
+				this.quadraticCurveTo(p[0], p[1], p[2], p[3]);
+				break;
+			case 5:
+				this.ellipse(p[0], p[1], p[2], p[3], p[6], p[4], p[4] + p[5],
+						(1 - p[7]) > 0);
+				break;
+			case 6:
+				return true;
+				break;
+			case 7:
+				this.arcTo(p[0], p[1], p[2], p[3], p[4]);
+				break;
+			}
+		}
+		return fill;
+    }-*/;
+
+    void fill(Path2D.NativePath2D path)
+    /*-{
+		if (path) {
+			this.fill(path);
+		}
+    }-*/;
+
+    void stroke(Path2D.NativePath2D path)
+    /*-{
+		if (path) {
+			this.stroke(path);
+		}
+    }-*/;
+
+    void clip(Path2D.NativePath2D path)
+    /*-{
+		if (path) {
+			this.clip(path);
+		}
+    }-*/;
+
+    Path2D.NativePath2D getCurrentPath()
+    /*-{
+		return this.currentPath || null;
+    }-*/;
+
+    void setCurrentPath(Path2D.NativePath2D path)
+    /*-{
+		if (path) {
+			this.currentPath = path;
+		}
+    }-*/;
+}

--- a/src/main/java/com/ait/lienzo/client/core/NativeContext2D.java
+++ b/src/main/java/com/ait/lienzo/client/core/NativeContext2D.java
@@ -36,8 +36,7 @@ import com.google.gwt.dom.client.Element;
  * @see <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/the-canvas-element.html#2dcontext">Canvas 2d Context</a> 
  */
 
-public final class NativeContext2D extends JavaScriptObject
-{
+public class NativeContext2D extends JavaScriptObject implements INativeContext2D {
     private static final native NativeContext2D make_0(CanvasElement element)
     /*-{
 		return element.getContext("2d");
@@ -125,86 +124,113 @@ public final class NativeContext2D extends JavaScriptObject
 		return this;
     }-*/;
 
+    @Override
+    public final void saveGroup() {
+        this.save();
+    }
+
+    @Override
+    public final void restoreGroup() {
+        this.restore();
+    }
+
+    @Override
     public final native void save()
     /*-{
 		this.save();
     }-*/;
 
+    @Override
     public final native void restore()
     /*-{
 		this.restore();
     }-*/;
 
+    @Override
     public final native void beginPath()
     /*-{
 		this.beginPath();
     }-*/;
 
+    @Override
     public final native void closePath()
     /*-{
 		this.closePath();
     }-*/;
 
+    @Override
     public final native void moveTo(double x, double y)
     /*-{
 		this.moveTo(x, y);
     }-*/;
 
+    @Override
     public final native void lineTo(double x, double y)
     /*-{
 		this.lineTo(x, y);
     }-*/;
 
+    @Override
     public final native void setGlobalCompositeOperation(String operation)
     /*-{
 		this.globalCompositeOperation = operation || "source-over";
     }-*/;
 
+    @Override
     public final native void setLineCap(String lineCap)
     /*-{
 		this.lineCap = lineCap || "butt";
     }-*/;
 
+    @Override
     public final native void setLineJoin(String lineJoin)
     /*-{
 		this.lineJoin = lineJoin || "miter";
     }-*/;
 
+    @Override
     public final native void quadraticCurveTo(double cpx, double cpy, double x, double y)
     /*-{
 		this.quadraticCurveTo(cpx, cpy, x, y);
     }-*/;
 
+    @Override
     public final native void arc(double x, double y, double radius, double startAngle, double endAngle)
     /*-{
 		this.arc(x, y, radius, startAngle, endAngle, false);
     }-*/;
 
+    @Override
     public final native void arc(double x, double y, double radius, double startAngle, double endAngle, boolean antiClockwise)
     /*-{
 		this.arc(x, y, radius, startAngle, endAngle, antiClockwise);
     }-*/;
 
+    @Override
     public final native void ellipse(double x, double y, double rx, double ry, double ro, double sa, double ea, boolean ac)
     /*-{
 		this.ellipse(x, y, rx, ry, ro, sa, ea, ac);
     }-*/;
 
+    @Override
     public final native void ellipse(double x, double y, double rx, double ry, double ro, double sa, double ea)
     /*-{
 		this.ellipse(x, y, rx, ry, ro, sa, ea, false);
     }-*/;
 
+    @Override
     public final native void arcTo(double x1, double y1, double x2, double y2, double radius)
     /*-{
 		this.arcTo(x1, y1, x2, y2, radius);
     }-*/;
 
+    @Override
     public final native void bezierCurveTo(double cp1x, double cp1y, double cp2x, double cp2y, double x, double y)
     /*-{
 		this.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, x, y);
     }-*/;
 
+    @Override
     public final native void clearRect(double x, double y, double w, double h)
     /*-{
 		if ((w <= 0) || (h <= 0)) {
@@ -213,21 +239,25 @@ public final class NativeContext2D extends JavaScriptObject
 		this.clearRect(x, y, w, h);
     }-*/;
 
+    @Override
     public final native void clip()
     /*-{
 		this.clip();
     }-*/;
 
+    @Override
     public final native void fill()
     /*-{
 		this.fill();
     }-*/;
 
+    @Override
     public final native void stroke()
     /*-{
 		this.stroke();
     }-*/;
 
+    @Override
     public final native void fillRect(double x, double y, double w, double h)
     /*-{
 		if ((w <= 0) || (h <= 0)) {
@@ -236,34 +266,39 @@ public final class NativeContext2D extends JavaScriptObject
 		this.fillRect(x, y, w, h);
     }-*/;
 
+    @Override
     public final native void fillText(String text, double x, double y)
     /*-{
 		this.fillText(text, x, y);
     }-*/;
 
+    @Override
     public final native void fillTextWithGradient(String text, double x, double y, double sx, double sy, double ex, double ey, String color)
     /*-{
-		var grad = this.createLinearGradient(sx, sy, ex, ey);
+        var grad = this.createLinearGradient(sx, sy, ex, ey);
 
-		grad.addColorStop(0, color);
+        grad.addColorStop(0, color);
 
-		grad.addColorStop(1, color);
+        grad.addColorStop(1, color);
 
-		this.fillStyle = grad;
+        this.fillStyle = grad;
 
-		this.fillText(text, x, y);
+        this.fillText(text, x, y);
     }-*/;
 
+    @Override
     public final native void fillText(String text, double x, double y, double maxWidth)
     /*-{
 		this.fillText(text, x, y, maxWidth);
     }-*/;
 
+    @Override
     public final native void setFillColor(String fill)
     /*-{
 		this.fillStyle = fill;
     }-*/;
 
+    @Override
     public final native void rect(double x, double y, double w, double h)
     /*-{
 		if ((w <= 0) || (h <= 0)) {
@@ -272,31 +307,37 @@ public final class NativeContext2D extends JavaScriptObject
 		this.rect(x, y, w, h);
     }-*/;
 
+    @Override
     public final native void rotate(double angle)
     /*-{
 		this.rotate(angle);
     }-*/;
 
+    @Override
     public final native void scale(double sx, double sy)
     /*-{
 		this.scale(sx*scalingRatio, sy*scalingRatio);
     }-*/;
 
+    @Override
     public final native void setStrokeColor(String color)
     /*-{
 		this.strokeStyle = color;
     }-*/;
 
+    @Override
     public final native void setStrokeWidth(double width)
     /*-{
 		this.lineWidth = width;
     }-*/;
 
+    @Override
     public final native void setImageSmoothingEnabled(boolean enabled)
     /*-{
 		this.imageSmoothingEnabled = enabled;
     }-*/;
 
+    @Override
     public final native void setFillGradient(LinearGradientJSO grad)
     /*-{
 		if (grad) {
@@ -314,6 +355,7 @@ public final class NativeContext2D extends JavaScriptObject
 		}
     }-*/;
 
+    @Override
     public final native void setFillGradient(PatternGradientJSO grad)
     /*-{
 		if ((grad) && ((typeof grad.image) === 'function')) {
@@ -328,6 +370,7 @@ public final class NativeContext2D extends JavaScriptObject
 		}
     }-*/;
 
+    @Override
     public final native void setFillGradient(RadialGradientJSO grad)
     /*-{
 		if (grad) {
@@ -345,6 +388,7 @@ public final class NativeContext2D extends JavaScriptObject
 		}
     }-*/;
 
+    @Override
     public final native void transform(TransformJSO jso)
     /*-{
 		if (jso) {
@@ -352,11 +396,13 @@ public final class NativeContext2D extends JavaScriptObject
 		}
     }-*/;
 
+    @Override
     public final native void transform(double d0, double d1, double d2, double d3, double d4, double d5)
     /*-{
 		this.transform(d0, d1, d2, d3, d4, d5);
     }-*/;
 
+    @Override
     public final native void setTransform(TransformJSO jso)
     /*-{
 		if (jso) {
@@ -364,46 +410,55 @@ public final class NativeContext2D extends JavaScriptObject
 		}
     }-*/;
 
+    @Override
     public final native void setTransform(double d0, double d1, double d2, double d3, double d4, double d5)
     /*-{
 		this.setTransform(d0, d1, d2, d3, d4, d5);
     }-*/;
 
+    @Override
     public final native void setToIdentityTransform()
     /*-{
 		this.setTransform(1, 0, 0, 1, 0, 0);
     }-*/;
 
+    @Override
     public final native void setTextFont(String font)
     /*-{
 		this.font = font;
     }-*/;
 
+    @Override
     public final native void setTextBaseline(String baseline)
     /*-{
 		this.textBaseline = baseline || "alphabetic";
     }-*/;
 
+    @Override
     public final native void setTextAlign(String align)
     /*-{
 		this.textAlign = align || "start";
     }-*/;
 
+    @Override
     public final native void strokeText(String text, double x, double y)
     /*-{
 		this.strokeText(text, x, y);
     }-*/;
 
+    @Override
     public final native void setGlobalAlpha(double alpha)
     /*-{
 		this.globalAlpha = alpha;
     }-*/;
 
+    @Override
     public final native void translate(double x, double y)
     /*-{
 		this.translate(x, y);
     }-*/;
 
+    @Override
     public final native void setShadow(ShadowJSO shadow)
     /*-{
 		if (shadow) {
@@ -419,36 +474,43 @@ public final class NativeContext2D extends JavaScriptObject
 		}
     }-*/;
 
+    @Override
     public final native boolean isSupported(String feature)
     /*-{
 		return (this[feature] !== undefined);
     }-*/;
 
+    @Override
     public final native boolean isPointInPath(double x, double y)
     /*-{
 		return this.isPointInPath(x, y);
     }-*/;
 
+    @Override
     public final native ImageData getImageData(double x, double y, double width, double height)
     /*-{
 		return this.getImageData(x, y, width, height);
     }-*/;
 
+    @Override
     public final native ImageData createImageData(double width, double height)
     /*-{
 		return this.createImageData(width, height);
     }-*/;
 
+    @Override
     public final native ImageData createImageData(ImageData data)
     /*-{
 		return this.createImageData(data);
     }-*/;
 
+    @Override
     public final native void putImageData(ImageData imageData, double x, double y)
     /*-{
 		this.putImageData(imageData, x, y);
     }-*/;
 
+    @Override
     public final native void putImageData(ImageData imageData, double x, double y, double dx, double dy, double dw, double dh)
     /*-{
 		if ((dw <= 0) || (dh <= 0)) {
@@ -463,16 +525,19 @@ public final class NativeContext2D extends JavaScriptObject
      * @param text the text to measure, as a String
      * @return a {@link TextMetrics} object
      */
+    @Override
     public final native TextMetrics measureText(String text)
     /*-{
 		return this.measureText(text);
     }-*/;
 
+    @Override
     public final native void drawImage(Element image, double x, double y)
     /*-{
 		this.drawImage(image, x, y);
     }-*/;
 
+    @Override
     public final native void drawImage(Element image, double x, double y, double w, double h)
     /*-{
 		if ((w <= 0) || (h <= 0)) {
@@ -481,6 +546,7 @@ public final class NativeContext2D extends JavaScriptObject
 		this.drawImage(image, x, y, w, h);
     }-*/;
 
+    @Override
     public final native void drawImage(Element image, double sx, double sy, double sw, double sh, double x, double y, double w, double h)
     /*-{
 		if ((w <= 0) || (h <= 0)) {
@@ -492,31 +558,37 @@ public final class NativeContext2D extends JavaScriptObject
 		this.drawImage(image, sx, sy, sw, sh, x, y, w, h);
     }-*/;
 
+    @Override
     public final native void resetClip()
     /*-{
 		this.resetClip();
     }-*/;
 
+    @Override
     public final native void setMiterLimit(double limit)
     /*-{
 		this.miterLimit = limit;
     }-*/;
 
+    @Override
     public final native void setLineDash(NFastDoubleArrayJSO dashes)
     /*-{
 		this.setLineDash(dashes || []);
     }-*/;
 
+    @Override
     public final native void setLineDashOffset(double offset)
     /*-{
 		this.setLineDashOffset(offset);
     }-*/;
 
+    @Override
     public final native double getBackingStorePixelRatio()
     /*-{
 		return this.backingStorePixelRatio || 1;
     }-*/;
 
+    @Override
     public final native boolean path(PathPartListJSO list)
     /*-{
 		if (!list) {
@@ -561,6 +633,7 @@ public final class NativeContext2D extends JavaScriptObject
 		return fill;
     }-*/;
 
+    @Override
     public final native boolean clip(PathPartListJSO list)
     /*-{
 		if (!list) {
@@ -603,6 +676,7 @@ public final class NativeContext2D extends JavaScriptObject
 		return fill;
     }-*/;
 
+    @Override
     public final native void fill(NativePath2D path)
     /*-{
 		if (path) {
@@ -610,6 +684,7 @@ public final class NativeContext2D extends JavaScriptObject
 		}
     }-*/;
 
+    @Override
     public final native void stroke(NativePath2D path)
     /*-{
 		if (path) {
@@ -617,6 +692,7 @@ public final class NativeContext2D extends JavaScriptObject
 		}
     }-*/;
 
+    @Override
     public final native void clip(NativePath2D path)
     /*-{
 		if (path) {
@@ -624,11 +700,13 @@ public final class NativeContext2D extends JavaScriptObject
 		}
     }-*/;
 
+    @Override
     public final native NativePath2D getCurrentPath()
     /*-{
 		return this.currentPath || null;
     }-*/;
 
+    @Override
     public final native void setCurrentPath(NativePath2D path)
     /*-{
 		if (path) {

--- a/src/main/java/com/ait/lienzo/client/core/Path2D.java
+++ b/src/main/java/com/ait/lienzo/client/core/Path2D.java
@@ -189,7 +189,7 @@ public class Path2D
         return this;
     }
 
-    static final class NativePath2D extends JavaScriptObject
+    public static final class NativePath2D extends JavaScriptObject
     {
         protected NativePath2D()
         {

--- a/src/main/java/com/ait/lienzo/client/core/shape/Layer.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/Layer.java
@@ -690,7 +690,7 @@ public class Layer extends ContainerNode<IPrimitive<?>, Layer>
         return draw(getContext());
     }
 
-    protected Layer draw(Context2D context)
+    public Layer draw(Context2D context)
     {
         if (LienzoCore.IS_CANVAS_SUPPORTED)
         {

--- a/src/main/java/com/ait/lienzo/client/core/shape/Node.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/Node.java
@@ -100,7 +100,6 @@ import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONValue;
-import com.google.gwt.touch.client.Point;
 
 /**
  * Node is the base class for {@link ContainerNode} and {@link Shape}.
@@ -487,7 +486,7 @@ public abstract class Node<T extends Node<T>> implements IDrawable<T>
         }
         if (context.isDrag() || isVisible())
         {
-            context.save();
+            context.saveGroup();
 
             final Transform xfrm = getPossibleNodeTransform();
 
@@ -497,7 +496,7 @@ public abstract class Node<T extends Node<T>> implements IDrawable<T>
             }
             drawWithoutTransforms(context, alpha, bounds);
 
-            context.restore();
+            context.restoreGroup();
         }
     }
 


### PR DESCRIPTION
Refactor creating the interface `INativeContext2D` that represents the `NativeContext2D` that is the default implementation of the native canvas context.

@romartin 
@mdproctor 
