### PR TITLE
JBPM-7111: Do not throw exception on size constraints validation.

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/AbstractMultiPathPartShape.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/AbstractMultiPathPartShape.java
@@ -147,11 +147,6 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
             }
         }
 
-        if (!validSizeConstraints())
-        {
-            throw new IllegalArgumentException("Constraints are either smaller or larger than size.");
-        }
-
         return true;
     }
 
@@ -231,50 +226,6 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
     {
         getAttributes().setSizeConstraints(sizeConstraints);
         return refresh();
-    }
-
-
-    private boolean validSizeConstraints()
-    {
-        BoundingBox shapeBB = getBoundingBox();
-
-        BoundingBox constraintsBB = getSizeConstraints();
-
-        if (constraintsBB == null)
-        {
-            return true;
-        }
-
-        final double minWidth = constraintsBB.getMinX();
-
-        final double minHeight = constraintsBB.getMinY();
-
-        final double maxWidth = constraintsBB.getMaxX();
-
-        final double maxHeight = constraintsBB.getMaxY();
-
-        final double width = shapeBB.getWidth();
-
-        final double height = shapeBB.getHeight();
-
-        if (minWidth > width)
-        {
-            return false;
-        }
-        if (minHeight > height)
-        {
-            return false;
-        }
-        if (maxWidth < width)
-        {
-            return false;
-        }
-        if (maxHeight < height)
-        {
-            return false;
-        }
-
-        return true;
     }
 
     public double getCornerRadius()


### PR DESCRIPTION
Hey @hasys @tiagodolphine 

See [JBPM-7111](https://issues.jboss.org/browse/JBPM-7111)

I guess this fix must be cherry-picked to `7.7.x` as well, will let you know. 

Please can you take a quick look?

Thanks