### PR TITLE
JBPM-7129 - Stunner - Allow optional size constraints for shapes 

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/Attribute.java
+++ b/src/main/java/com/ait/lienzo/client/core/Attribute.java
@@ -31,13 +31,13 @@ public class Attribute
 
     public static final Attribute           HEIGHT                           = new Attribute("height", MESSAGES.heightLabel(), MESSAGES.heightDescription(), AttributeType.NUMBER_TYPE, true);
 
-    public static final Attribute MIN_WIDTH = new Attribute("minWidth", MESSAGES.minWidthLabel(), MESSAGES.minWidthDescription(), AttributeType.NUMBER_TYPE, true);
+    public static final Attribute           MIN_WIDTH                        = new Attribute("minWidth", MESSAGES.minWidthLabel(), MESSAGES.minWidthDescription(), AttributeType.NUMBER_TYPE, true);
 
-    public static final Attribute MAX_WIDTH = new Attribute("maxWidth", MESSAGES.maxWidthLabel(), MESSAGES.maxWidthDescription(), AttributeType.NUMBER_TYPE, true);
+    public static final Attribute           MAX_WIDTH                        = new Attribute("maxWidth", MESSAGES.maxWidthLabel(), MESSAGES.maxWidthDescription(), AttributeType.NUMBER_TYPE, true);
 
-    public static final Attribute MIN_HEIGHT = new Attribute("minHeight", MESSAGES.minHeightLabel(), MESSAGES.minHeightDescription(), AttributeType.NUMBER_TYPE, true);
+    public static final Attribute           MIN_HEIGHT                       = new Attribute("minHeight", MESSAGES.minHeightLabel(), MESSAGES.minHeightDescription(), AttributeType.NUMBER_TYPE, true);
 
-    public static final Attribute MAX_HEIGHT = new Attribute("maxHeight", MESSAGES.maxHeightLabel(), MESSAGES.maxHeightDescription(), AttributeType.NUMBER_TYPE, true);
+    public static final Attribute           MAX_HEIGHT                       = new Attribute("maxHeight", MESSAGES.maxHeightLabel(), MESSAGES.maxHeightDescription(), AttributeType.NUMBER_TYPE, true);
 
     public static final Attribute           CORNER_RADIUS                    = new Attribute("cornerRadius", MESSAGES.cornerRadiusLabel(), MESSAGES.cornerRadiusDescription(), AttributeType.NUMBER_TYPE, true);
 

--- a/src/main/java/com/ait/lienzo/client/core/Attribute.java
+++ b/src/main/java/com/ait/lienzo/client/core/Attribute.java
@@ -31,9 +31,15 @@ public class Attribute
 
     public static final Attribute           HEIGHT                           = new Attribute("height", MESSAGES.heightLabel(), MESSAGES.heightDescription(), AttributeType.NUMBER_TYPE, true);
 
-    public static final Attribute           CORNER_RADIUS                    = new Attribute("cornerRadius", MESSAGES.cornerRadiusLabel(), MESSAGES.cornerRadiusDescription(), AttributeType.NUMBER_TYPE, true);
+    public static final Attribute MIN_WIDTH = new Attribute("minWidth", MESSAGES.minWidthLabel(), MESSAGES.minWidthDescription(), AttributeType.NUMBER_TYPE, true);
 
-    public static final Attribute           SIZE_CONSTRAINTS                 = new Attribute("sizeConstraints", MESSAGES.sizeConstraintsLabel(), MESSAGES.sizeConstraintsDescription(), AttributeType.NUMBER_TYPE, true);
+    public static final Attribute MAX_WIDTH = new Attribute("maxWidth", MESSAGES.maxWidthLabel(), MESSAGES.maxWidthDescription(), AttributeType.NUMBER_TYPE, true);
+
+    public static final Attribute MIN_HEIGHT = new Attribute("minHeight", MESSAGES.minHeightLabel(), MESSAGES.minHeightDescription(), AttributeType.NUMBER_TYPE, true);
+
+    public static final Attribute MAX_HEIGHT = new Attribute("maxHeight", MESSAGES.maxHeightLabel(), MESSAGES.maxHeightDescription(), AttributeType.NUMBER_TYPE, true);
+
+    public static final Attribute           CORNER_RADIUS                    = new Attribute("cornerRadius", MESSAGES.cornerRadiusLabel(), MESSAGES.cornerRadiusDescription(), AttributeType.NUMBER_TYPE, true);
 
     public static final Attribute           FILL                             = new Attribute("fill", MESSAGES.fillLabel(), MESSAGES.fillDescription(), AttributeType.FILL_TYPE, true);
 

--- a/src/main/java/com/ait/lienzo/client/core/i18n/MessageConstants.java
+++ b/src/main/java/com/ait/lienzo/client/core/i18n/MessageConstants.java
@@ -87,17 +87,35 @@ public interface MessageConstants extends Constants
     @DefaultStringValue("Height value in pixels.")
     public String heightDescription();
 
+    @DefaultStringValue("Min Width")
+    public String minWidthLabel();
+
+    @DefaultStringValue("Minimum Width value in pixels.")
+    public String minWidthDescription();
+
+    @DefaultStringValue("Max Width")
+    public String maxWidthLabel();
+
+    @DefaultStringValue("Maximum Width value in pixels.")
+    public String maxWidthDescription();
+
+    @DefaultStringValue("Min Height")
+    public String minHeightLabel();
+
+    @DefaultStringValue("Minimum Height value in pixels.")
+    public String minHeightDescription();
+
+    @DefaultStringValue("Max Height")
+    public String maxHeightLabel();
+
+    @DefaultStringValue("Maximum Height value in pixels.")
+    public String maxHeightDescription();
+
     @DefaultStringValue("Corner Radius")
     public String cornerRadiusLabel();
 
     @DefaultStringValue("The radius of a 90 degree arc, which is used as a rounded corner.")
     public String cornerRadiusDescription();
-
-    @DefaultStringValue("Size constraints")
-    public String sizeConstraintsLabel();
-
-    @DefaultStringValue("Min/Max width and Min/Max height constraint values in pixels.")
-    public String sizeConstraintsDescription();
 
     @DefaultStringValue("Fill")
     public String fillLabel();

--- a/src/main/java/com/ait/lienzo/client/core/shape/AbstractMultiPathPartShape.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/AbstractMultiPathPartShape.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.ait.lienzo.client.core.Attribute;
 import com.ait.lienzo.client.core.Context2D;
 import com.ait.lienzo.client.core.animation.AnimationProperties;
 import com.ait.lienzo.client.core.animation.AnimationProperty;
@@ -217,14 +218,75 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
         }
     }
 
-    public BoundingBox getSizeConstraints()
-    {
-        return getAttributes().getSizeConstraints();
+    public Double getMinWidth() {
+        if (getAttributes().isDefined(Attribute.MIN_WIDTH)) {
+            return getAttributes().getMinWidth();
+        } else {
+            return null;
+        }
     }
 
-    public T setSizeConstraints(final BoundingBox sizeConstraints)
-    {
-        getAttributes().setSizeConstraints(sizeConstraints);
+    public T setMinWidth(Double minWidth) {
+        if (minWidth != null) {
+            getAttributes().setMinWidth(minWidth);
+        } else {
+            getAttributes().remove(Attribute.MIN_WIDTH.getProperty());
+        }
+
+        return refresh();
+    }
+
+    public Double getMaxWidth() {
+        if (getAttributes().isDefined(Attribute.MAX_WIDTH)) {
+            return getAttributes().getMaxWidth();
+        } else {
+            return null;
+        }
+    }
+
+    public T setMaxWidth(Double maxWidth) {
+        if (maxWidth != null) {
+            getAttributes().setMaxWidth(maxWidth);
+        } else {
+            getAttributes().remove(Attribute.MAX_WIDTH.getProperty());
+        }
+
+        return refresh();
+    }
+
+    public Double getMinHeight() {
+        if (getAttributes().isDefined(Attribute.MIN_HEIGHT)) {
+            return getAttributes().getMinHeight();
+        } else {
+            return null;
+        }
+    }
+
+    public T setMinHeight(Double minHeight) {
+        if (minHeight != null) {
+            getAttributes().setMinHeight(minHeight);
+        } else {
+            getAttributes().remove(Attribute.MIN_HEIGHT.getProperty());
+        }
+
+        return refresh();
+    }
+
+    public Double getMaxHeight() {
+        if (getAttributes().isDefined(Attribute.MAX_HEIGHT)) {
+            return getAttributes().getMaxHeight();
+        } else {
+            return null;
+        }
+    }
+
+    public T setMaxHeight(Double maxHeight) {
+        if (maxHeight != null) {
+            getAttributes().setMaxHeight(maxHeight);
+        } else {
+            getAttributes().remove(Attribute.MAX_HEIGHT.getProperty());
+        }
+
         return refresh();
     }
 
@@ -332,13 +394,14 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
 
     public static final class DefaultMultiPathShapeHandleFactory implements IControlHandleFactory
     {
+
         private final NFastArrayList<PathPartList> m_listOfPaths;
 
-        private final Shape<?>                     m_shape;
+        private final AbstractMultiPathPartShape<?> m_shape;
 
-        private DragMode                           m_dmode = DragMode.SAME_LAYER;
+        private DragMode m_dmode = DragMode.SAME_LAYER;
 
-        public DefaultMultiPathShapeHandleFactory(NFastArrayList<PathPartList> listOfPaths, Shape<?> shape)
+        public DefaultMultiPathShapeHandleFactory(NFastArrayList<PathPartList> listOfPaths, AbstractMultiPathPartShape<?> shape)
         {
             m_listOfPaths = listOfPaths;
 
@@ -444,7 +507,7 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
             node.animate(AnimationTweener.LINEAR, AnimationProperties.toPropertyList(property), ANIMATION_DURATION);
         }
 
-        public static IControlHandleList getResizeHandles(Shape<?> shape, NFastArrayList<PathPartList> listOfPaths, DragMode dragMode)
+        public static IControlHandleList getResizeHandles(AbstractMultiPathPartShape<?> shape, NFastArrayList<PathPartList> listOfPaths, DragMode dragMode)
         {
             // FIXME This isn't quite right yet, do not release  (mdp, um what did I mean here?)
 
@@ -491,7 +554,7 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
             return chlist;
         }
 
-        private static ResizeControlHandle getResizeControlHandle(IControlHandleList chlist, ArrayList<ResizeControlHandle> orderedChList, Shape<?> shape, NFastArrayList<PathPartList> listOfPaths, Point2D point, int position, DragMode dragMode)
+        private static ResizeControlHandle getResizeControlHandle(IControlHandleList chlist, ArrayList<ResizeControlHandle> orderedChList, AbstractMultiPathPartShape<?> shape, NFastArrayList<PathPartList> listOfPaths, Point2D point, int position, DragMode dragMode)
         {
             final Circle prim = getControlPrimitive(R0, point.getX(), point.getY(), shape, dragMode);
 
@@ -712,7 +775,8 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
 
     private static class ResizeControlHandle extends AbstractControlHandle
     {
-        private final Shape<?>                       m_shape;
+
+        private final AbstractMultiPathPartShape<?> m_shape;
 
         private final NFastArrayList<PathPartList>   m_listOfPaths;
 
@@ -724,7 +788,7 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
 
         private int                                  m_position;
 
-        public ResizeControlHandle(Circle prim, IControlHandleList hlist, ArrayList<ResizeControlHandle> orderedChList, Shape<?> shape, NFastArrayList<PathPartList> listOfPaths, int position)
+        public ResizeControlHandle(Circle prim, IControlHandleList hlist, ArrayList<ResizeControlHandle> orderedChList, AbstractMultiPathPartShape<?> shape, NFastArrayList<PathPartList> listOfPaths, int position)
         {
             m_prim = prim;
 
@@ -903,7 +967,8 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
 
     public static class ResizeHandleDragHandler implements DragConstraintEnforcer, NodeDragEndHandler
     {
-        private final Shape<?>                      m_shape;
+
+        private final AbstractMultiPathPartShape<?> m_shape;
 
         private final NFastArrayList<PathPartList>  m_listOfPaths;
 
@@ -927,7 +992,7 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
 
         private double                              m_offsetY;
 
-        public ResizeHandleDragHandler(Shape<?> shape, NFastArrayList<PathPartList> listOfPaths, IControlHandleList chlist, Shape<?> prim, ResizeControlHandle handle)
+        public ResizeHandleDragHandler(AbstractMultiPathPartShape<?> shape, NFastArrayList<PathPartList> listOfPaths, IControlHandleList chlist, Shape<?> prim, ResizeControlHandle handle)
         {
             m_shape = shape;
 
@@ -1167,20 +1232,13 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
 
         public boolean adjustPrimitive(Point2D dxy)
         {
-            BoundingBox sizeConstraints = m_shape.getAttributes().getSizeConstraints();
+            Double minWidth = m_shape.getMinWidth();
 
-            if (sizeConstraints == null)
-            {
-                return true;
-            }
+            Double maxWidth = m_shape.getMaxWidth();
 
-            double minWidth = sizeConstraints.getMinX();
+            Double minHeight = m_shape.getMinHeight();
 
-            double maxWidth = sizeConstraints.getMaxX();
-
-            double minHeight = sizeConstraints.getMinY();
-
-            double maxHeight = sizeConstraints.getMaxY();
+            Double maxHeight = m_shape.getMaxHeight();
 
             Point2D adjustedDelta = adjustForPosition(dxy);
 
@@ -1194,7 +1252,7 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
 
             boolean needsAdjustment = false;
 
-            if (width < minWidth)
+            if (minWidth != null && width < minWidth)
             {
                 double difference = width - minWidth;
 
@@ -1205,7 +1263,7 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
                 needsAdjustment = true;
             }
 
-            if (width > maxWidth)
+            if (maxWidth != null && width > maxWidth)
             {
                 double difference = width - maxWidth;
 
@@ -1216,7 +1274,7 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
                 needsAdjustment = true;
             }
 
-            if (height < minHeight)
+            if (minHeight != null && height < minHeight)
             {
                 double difference = height - minHeight;
 
@@ -1227,7 +1285,7 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
                 needsAdjustment = true;
             }
 
-            if (height > maxHeight)
+            if (maxHeight != null && height > maxHeight)
             {
                 double difference = height - maxHeight;
 

--- a/src/main/java/com/ait/lienzo/client/core/shape/AbstractMultiPathPartShape.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/AbstractMultiPathPartShape.java
@@ -226,13 +226,8 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
         }
     }
 
-    public T setMinWidth(Double minWidth) {
-        if (minWidth != null) {
-            getAttributes().setMinWidth(minWidth);
-        } else {
-            getAttributes().remove(Attribute.MIN_WIDTH.getProperty());
-        }
-
+    public T setMinWidth(final Double minWidth) {
+        getAttributes().setMinWidth(minWidth);
         return refresh();
     }
 
@@ -244,13 +239,8 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
         }
     }
 
-    public T setMaxWidth(Double maxWidth) {
-        if (maxWidth != null) {
-            getAttributes().setMaxWidth(maxWidth);
-        } else {
-            getAttributes().remove(Attribute.MAX_WIDTH.getProperty());
-        }
-
+    public T setMaxWidth(final Double maxWidth) {
+        getAttributes().setMaxWidth(maxWidth);
         return refresh();
     }
 
@@ -262,13 +252,8 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
         }
     }
 
-    public T setMinHeight(Double minHeight) {
-        if (minHeight != null) {
-            getAttributes().setMinHeight(minHeight);
-        } else {
-            getAttributes().remove(Attribute.MIN_HEIGHT.getProperty());
-        }
-
+    public T setMinHeight(final Double minHeight) {
+        getAttributes().setMinHeight(minHeight);
         return refresh();
     }
 
@@ -280,13 +265,8 @@ public abstract class AbstractMultiPathPartShape<T extends AbstractMultiPathPart
         }
     }
 
-    public T setMaxHeight(Double maxHeight) {
-        if (maxHeight != null) {
-            getAttributes().setMaxHeight(maxHeight);
-        } else {
-            getAttributes().remove(Attribute.MAX_HEIGHT.getProperty());
-        }
-
+    public T setMaxHeight(final Double maxHeight) {
+        getAttributes().setMaxHeight(maxHeight);
         return refresh();
     }
 

--- a/src/main/java/com/ait/lienzo/client/core/shape/Attributes.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/Attributes.java
@@ -788,20 +788,52 @@ public class Attributes
         put(Attribute.HEIGHT.getProperty(), height);
     }
 
-    public final void setMinWidth(final double minWidth) {
-        put(Attribute.MIN_WIDTH.getProperty(), minWidth);
+    public final void setMinWidth(final Double minWidth)
+    {
+        if (null != minWidth)
+        {
+            put(Attribute.MIN_WIDTH.getProperty(), minWidth);
+        }
+        else
+        {
+            remove(Attribute.MIN_WIDTH.getProperty());
+        }
     }
 
-    public final void setMaxWidth(final double maxWidth) {
-        put(Attribute.MAX_WIDTH.getProperty(), maxWidth);
+    public final void setMaxWidth(final Double maxWidth)
+    {
+        if (null != maxWidth)
+        {
+            put(Attribute.MAX_WIDTH.getProperty(), maxWidth);
+        }
+        else
+        {
+            remove(Attribute.MAX_WIDTH.getProperty());
+        }
     }
 
-    public final void setMinHeight(final double minHeight) {
-        put(Attribute.MIN_HEIGHT.getProperty(), minHeight);
+    public final void setMinHeight(final Double minHeight)
+    {
+        if (null != minHeight)
+        {
+            put(Attribute.MIN_HEIGHT.getProperty(), minHeight);
+        }
+        else
+        {
+            remove(Attribute.MIN_HEIGHT.getProperty());
+        }
     }
 
-    public final void setMaxHeight(final double maxHeight) {
-        put(Attribute.MAX_HEIGHT.getProperty(), maxHeight);
+    public final void setMaxHeight(final Double maxHeight)
+    {
+        if (null != maxHeight)
+        {
+            put(Attribute.MAX_HEIGHT.getProperty(), maxHeight);
+        }
+        else
+        {
+            remove(Attribute.MAX_HEIGHT.getProperty());
+        }
     }
 
     public final void setPoints(final Point2DArray points)
@@ -1082,19 +1114,23 @@ public class Attributes
     }
 
     public final Double getMinWidth() {
-        return getDouble(Attribute.MIN_WIDTH.getProperty());
+        double minWidth = getDouble(Attribute.MIN_WIDTH.getProperty());
+        return minWidth == 0 ? null : minWidth;
     }
 
     public final Double getMaxWidth() {
-        return getDouble(Attribute.MAX_WIDTH.getProperty());
+        double maxWidth = getDouble(Attribute.MAX_WIDTH.getProperty());
+        return maxWidth == 0 ? null : maxWidth;
     }
 
     public final Double getMinHeight() {
-        return getDouble(Attribute.MIN_HEIGHT.getProperty());
+        double minHeight = getDouble(Attribute.MIN_HEIGHT.getProperty());
+        return minHeight == 0 ? null : minHeight;
     }
 
     public final Double getMaxHeight() {
-        return getDouble(Attribute.MAX_HEIGHT.getProperty());
+        double maxHeight = getDouble(Attribute.MAX_HEIGHT.getProperty());
+        return maxHeight == 0 ? null : maxHeight;
     }
 
     public final int getStarPoints()

--- a/src/main/java/com/ait/lienzo/client/core/shape/Attributes.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/Attributes.java
@@ -24,7 +24,6 @@ import com.ait.lienzo.client.core.event.IAttributesChangedBatcher;
 import com.ait.lienzo.client.core.event.ImmediateAttributesChangedBatcher;
 import com.ait.lienzo.client.core.image.filter.ImageDataFilter.FilterConvolveMatrix;
 import com.ait.lienzo.client.core.shape.json.IJSONSerializable;
-import com.ait.lienzo.client.core.types.BoundingBox;
 import com.ait.lienzo.client.core.types.DashArray;
 import com.ait.lienzo.client.core.types.DragBounds;
 import com.ait.lienzo.client.core.types.DragBounds.DragBoundsJSO;
@@ -646,19 +645,6 @@ public class Attributes
         put(Attribute.CORNER_RADIUS.getProperty(), cornerRadius);
     }
 
-    public final void setSizeConstraints(final BoundingBox boundingBox)
-    {
-        if (null != boundingBox)
-        {
-            put(Attribute.SIZE_CONSTRAINTS.getProperty(), boundingBox.getJSO());
-        }
-        else
-        {
-            remove(Attribute.SIZE_CONSTRAINTS.getProperty());
-        }
-    }
-
-
     public final void setAlpha(double alpha)
     {
         if (alpha < 0)
@@ -800,6 +786,22 @@ public class Attributes
     public final void setHeight(final double height)
     {
         put(Attribute.HEIGHT.getProperty(), height);
+    }
+
+    public final void setMinWidth(final double minWidth) {
+        put(Attribute.MIN_WIDTH.getProperty(), minWidth);
+    }
+
+    public final void setMaxWidth(final double maxWidth) {
+        put(Attribute.MAX_WIDTH.getProperty(), maxWidth);
+    }
+
+    public final void setMinHeight(final double minHeight) {
+        put(Attribute.MIN_HEIGHT.getProperty(), minHeight);
+    }
+
+    public final void setMaxHeight(final double maxHeight) {
+        put(Attribute.MAX_HEIGHT.getProperty(), maxHeight);
     }
 
     public final void setPoints(final Point2DArray points)
@@ -1069,19 +1071,6 @@ public class Attributes
         return getDouble(Attribute.CORNER_RADIUS.getProperty());
     }
 
-    public final BoundingBox getSizeConstraints()
-    {
-        final JavaScriptObject sizeConstraints = getObject(Attribute.SIZE_CONSTRAINTS.getProperty());
-
-        if (null != sizeConstraints)
-        {
-            final BoundingBox.BoundingBoxJSO bbjso = sizeConstraints.cast();
-
-            return new BoundingBox(bbjso);
-        }
-        return null;
-    }
-
     public final double getWidth()
     {
         return getDouble(Attribute.WIDTH.getProperty());
@@ -1090,6 +1079,22 @@ public class Attributes
     public final double getHeight()
     {
         return getDouble(Attribute.HEIGHT.getProperty());
+    }
+
+    public final Double getMinWidth() {
+        return getDouble(Attribute.MIN_WIDTH.getProperty());
+    }
+
+    public final Double getMaxWidth() {
+        return getDouble(Attribute.MAX_WIDTH.getProperty());
+    }
+
+    public final Double getMinHeight() {
+        return getDouble(Attribute.MIN_HEIGHT.getProperty());
+    }
+
+    public final Double getMaxHeight() {
+        return getDouble(Attribute.MAX_HEIGHT.getProperty());
     }
 
     public final int getStarPoints()


### PR DESCRIPTION
https://issues.jboss.org/browse/JBPM-7129

AbstractMultiPathPartShapes now supports adding min or max Constraints.
You can set minWidth, maxWidth, minHeight, maxHeight independent from
each other. For example you can set the minWidth for a shape and leave
all other constraints blank. Blank constraints will be ignored.

All this PR's are related to this task:
lienzo-core:
This PR

lienzo-tests:
https://github.com/kiegroup/lienzo-tests/pull/14

kie-wb-common
https://github.com/kiegroup/kie-wb-common/pull/1641