### PR TITLE
JBPM-7145 SVG persisted on backend when saving a diagram

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/Context2D.java
+++ b/src/main/java/com/ait/lienzo/client/core/Context2D.java
@@ -62,8 +62,8 @@ public class Context2D
     /**
      * Save and push a new container context to the stack
      */
-    public void saveContainer(){
-        m_jso.saveContainer();
+    public void saveContainer(String id){
+        m_jso.saveContainer(id);
     }
 
     /**

--- a/src/main/java/com/ait/lienzo/client/core/INativeContext2D.java
+++ b/src/main/java/com/ait/lienzo/client/core/INativeContext2D.java
@@ -31,7 +31,7 @@ public interface INativeContext2D {
 
     void initDeviceRatio();
 
-    void saveContainer();
+    void saveContainer(String id);
 
     void restoreContainer();
 

--- a/src/main/java/com/ait/lienzo/client/core/NativeContext2D.java
+++ b/src/main/java/com/ait/lienzo/client/core/NativeContext2D.java
@@ -124,7 +124,7 @@ public class NativeContext2D extends JavaScriptObject implements INativeContext2
 		return this;
     }-*/;
 
-    public final void saveContainer() {
+    public final void saveContainer(String id) {
         this.save();
     }
 

--- a/src/main/java/com/ait/lienzo/client/core/shape/Node.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/Node.java
@@ -486,7 +486,7 @@ public abstract class Node<T extends Node<T>> implements IDrawable<T>
         }
         if (context.isDrag() || isVisible())
         {
-            context.saveContainer();
+            context.saveContainer(getID());
 
             final Transform xfrm = getPossibleNodeTransform();
 


### PR DESCRIPTION
To allow SVG to be saved on backend with the right node id, it was necessary to insert the id o nodes on the Context2D calls, that is used by the Canvas2Svg were are using to generate the SVG based on the same calls made to draw the canvas.

@romartin 
@LuboTerifaj 