### PR TITLE
JBPM-7245  Diagram SVG is not highlighted on the WB

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/Context2D.java
+++ b/src/main/java/com/ait/lienzo/client/core/Context2D.java
@@ -81,6 +81,10 @@ public class Context2D
         m_jso.save();
     }
 
+    public void save(String id){
+        m_jso.save(id);
+    }
+
     /**
      * Restore the saved context state (i.e style, fill, stroke...) by popping from the stack
      */

--- a/src/main/java/com/ait/lienzo/client/core/INativeContext2D.java
+++ b/src/main/java/com/ait/lienzo/client/core/INativeContext2D.java
@@ -35,6 +35,8 @@ public interface INativeContext2D {
 
     void restoreContainer();
 
+    void save(String id);
+
     void save();
 
     void restore();

--- a/src/main/java/com/ait/lienzo/client/core/NativeContext2D.java
+++ b/src/main/java/com/ait/lienzo/client/core/NativeContext2D.java
@@ -132,6 +132,10 @@ public class NativeContext2D extends JavaScriptObject implements INativeContext2
         this.restore();
     }
 
+    public final void save(String id) {
+        this.save();
+    }
+
     public final native void save()
     /*-{
 		this.save();

--- a/src/main/java/com/ait/lienzo/client/core/shape/Shape.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/Shape.java
@@ -317,7 +317,7 @@ public abstract class Shape<T extends Shape<T>> extends Node<T> implements IPrim
             {
                 return false;
             }
-            context.save();
+            context.save(getID());
 
             if (attr.hasShadow())
             {
@@ -450,7 +450,7 @@ public abstract class Shape<T extends Shape<T>> extends Node<T> implements IPrim
             {
                 return false;
             }
-            context.save();
+            context.save(getID());
 
             if (attr.hasShadow())
             {
@@ -571,7 +571,7 @@ public abstract class Shape<T extends Shape<T>> extends Node<T> implements IPrim
         }
         else
         {
-            context.save();
+            context.save(getID());
 
             context.setGlobalAlpha(alpha);
         }


### PR DESCRIPTION
Changes to support Diagram SVG is not highlighted on the WB (jbpm-process-svg widget).
Insert the shape id in the same way it was done for the containers.

PS: unit tests will be updated later, the PR is to be tested ASAP since this is a blocker.

@romartin 
@LuboTerifaj 