### PR TITLE
JBPM-7332 Performance improvements: Lienzo Layer batch() to avoid requestAnimation

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/animation/LayerRedrawManager.java
+++ b/src/main/java/com/ait/lienzo/client/core/animation/LayerRedrawManager.java
@@ -13,21 +13,21 @@
    See the License for the specific language governing permissions and
    limitations under the License.
  */
-
 package com.ait.lienzo.client.core.animation;
 
 import com.ait.lienzo.client.core.shape.Layer;
 import com.ait.tooling.nativetools.client.collection.NFastArrayList;
 import com.google.gwt.animation.client.AnimationScheduler;
 import com.google.gwt.animation.client.AnimationScheduler.AnimationCallback;
+import com.google.gwt.dom.client.Element;
 
 public final class LayerRedrawManager
 {
-    private static final LayerRedrawManager INSTANCE = new LayerRedrawManager();
+    private static final LayerRedrawManager    INSTANCE = new LayerRedrawManager();
 
-    private final AnimationCallback         m_redraw;
+    private final        AnimationCallback     m_redraw;
 
-    private NFastArrayList<Layer>           m_layers = new NFastArrayList<Layer>();
+    private              NFastArrayList<Layer> m_layers = new NFastArrayList<Layer>();
 
     public static final LayerRedrawManager get()
     {
@@ -45,9 +45,8 @@ public final class LayerRedrawManager
 
                 if (size > 0)
                 {
-                    final NFastArrayList<Layer> list = m_layers;
-
-                    m_layers = new NFastArrayList<Layer>();
+                    final NFastArrayList<Layer> list = m_layers.copy();
+                    m_layers.clear();
 
                     for (int i = 0; i < size; i++)
                     {
@@ -65,18 +64,17 @@ public final class LayerRedrawManager
             if (false == m_layers.contains(layer))
             {
                 m_layers.add(layer.doBatchScheduled());
-
-                kick();
+                kick(layer.getElement());
             }
         }
         return layer;
     }
 
-    private void kick()
+    private void kick(Element layerElement)
     {
-        if (m_layers.size() > 0)
+        if (!m_layers.isEmpty())
         {
-            AnimationScheduler.get().requestAnimationFrame(m_redraw);
+            AnimationScheduler.get().requestAnimationFrame(m_redraw, layerElement);
         }
     }
 }

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/SelectionManager.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/SelectionManager.java
@@ -439,8 +439,6 @@ public class SelectionManager implements NodeMouseDoubleClickHandler, NodeMouseC
             destroySelectionShape();
             m_selected.clear();
             m_selected.notifyListener();
-            m_layer.batch();
-            m_layer.getViewport().getOverLayer().batch();
         }
     }
 
@@ -1288,8 +1286,6 @@ public class SelectionManager implements NodeMouseDoubleClickHandler, NodeMouseC
                 m_selectionManager.m_selectionShapeProvider
                         .setSize(attrs[2], attrs[3]);
             }
-            m_selectionManager.m_layer.batch();
-            m_selectionManager.m_layer.getViewport().getOverLayer().batch();
         }
 
         private WiresManager getWiresManager() {

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/WiresShapeHandlerImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/WiresShapeHandlerImpl.java
@@ -49,7 +49,6 @@ public class WiresShapeHandlerImpl extends WiresManager.WiresDragHandler impleme
                                     PickerPart.ShapePart.BODY);
             }
         }
-        batch();
     }
 
     @Override
@@ -91,9 +90,6 @@ public class WiresShapeHandlerImpl extends WiresManager.WiresDragHandler impleme
                                 PickerPart.ShapePart.BODY);
             }
         }
-
-        batch();
-
         return adjusted;
     }
 
@@ -117,8 +113,6 @@ public class WiresShapeHandlerImpl extends WiresManager.WiresDragHandler impleme
 
         // Restore highlights, if any.
         highlight.restore();
-
-        batch();
     }
 
     @Override
@@ -174,9 +168,5 @@ public class WiresShapeHandlerImpl extends WiresManager.WiresDragHandler impleme
 
     private boolean isDocked(final WiresShape shape) {
         return null != shape.getDockedTo();
-    }
-
-    void batch() {
-        getShape().getGroup().getLayer().batch();
     }
 }

--- a/src/main/java/com/ait/lienzo/client/widget/LienzoHandlerManager.java
+++ b/src/main/java/com/ait/lienzo/client/widget/LienzoHandlerManager.java
@@ -563,23 +563,20 @@ final class LienzoHandlerManager
             }
             m_lienzo.setCursor(cursor);
 
+            m_drag_node.fireEvent(new NodeDragEndEvent(m_dragContext));
+
+            m_dragContext.dragDone();
+
+            m_drag_node.setDragging(false);
+
             if (DragMode.DRAG_LAYER == m_drag_mode)
             {
                 m_drag_node.setVisible(true);
-
-                m_dragContext.dragDone();
 
                 m_drag_node.getLayer().draw();
 
                 m_lienzo.getDragLayer().clear();
             }
-            else
-            {
-                m_dragContext.dragDone();
-            }
-            m_drag_node.setDragging(false);
-
-            m_drag_node.fireEvent(new NodeDragEndEvent(m_dragContext));
 
             m_drag_node = null;
 


### PR DESCRIPTION
Some changes to reduce the `requestAnimation` calls to improve canvas performance.
The main point was on the **Dragging**, where the `WiresShapeHandlerImpl` as dupplicating calls to batch that were already done on the `LienzoHandlerManager` directly with the `draw()`. On the move this may have a considerable impact on performance.

@mdproctor @romartin @hasys  
can you please help to review these changes?
On profiler it seems the the requestAnimation has less impact then before.