### PR TITLE
JBPM-6882 Stunner - Control points are always pinned to a Process

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/ShapeControlUtils.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/ShapeControlUtils.java
@@ -1,19 +1,24 @@
 package com.ait.lienzo.client.core.shape.wires.handlers.impl;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
 import com.ait.lienzo.client.core.shape.IDirectionalMultiPointShape;
 import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.OrthogonalPolyLine;
-import com.ait.lienzo.client.core.shape.wires.*;
+import com.ait.lienzo.client.core.shape.wires.WiresConnection;
+import com.ait.lienzo.client.core.shape.wires.WiresConnector;
+import com.ait.lienzo.client.core.shape.wires.WiresContainer;
+import com.ait.lienzo.client.core.shape.wires.WiresMagnet;
+import com.ait.lienzo.client.core.shape.wires.WiresManager;
+import com.ait.lienzo.client.core.shape.wires.WiresShape;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresConnectorHandler;
 import com.ait.lienzo.client.core.types.BoundingBox;
 import com.ait.lienzo.client.core.types.PathPartList;
 import com.ait.lienzo.client.core.types.Point2D;
 import com.ait.lienzo.client.core.types.Point2DArray;
 import com.ait.lienzo.client.core.util.Geometry;
-
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 
 public class ShapeControlUtils {
 

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresCompositeControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresCompositeControlImpl.java
@@ -127,18 +127,7 @@ public class WiresCompositeControlImpl
             }
         }
 
-        final Collection<WiresConnector> connectors = selectedConnectors;
-        if (!connectors.isEmpty()) {
-            // Update connectors and connections.
-            for (WiresConnector connector : connectors) {
-                WiresConnectorHandler handler = connector.getWiresConnectorHandler();
-                handler.getControl().move(dx,
-                                          dy,
-                                          true,
-                                          true);
-                WiresConnector.updateHeadTailForRefreshedConnector(connector);
-            }
-        }
+        ShapeControlUtils.updateConnectors(selectedConnectors, dx, dy);
 
         ShapeControlUtils.updateSpecialConnections(m_connectorsWithSpecialConnections,
                                                    false);

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresShapeControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresShapeControlImpl.java
@@ -100,11 +100,14 @@ public class WiresShapeControlImpl
         // index nested shapes that have special m_connectors, to avoid searching during drag.
         m_connectorsWithSpecialConnections = ShapeControlUtils.collectionSpecialConnectors(getShape());
 
-        m_connectors = setConnectorsMoveStart(ShapeControlUtils.getConnectors(getShape()).values(), x, y);
+        //setting the child connectors that should be moved with the Shape
+        if(getShape().getChildShapes() != null && !getShape().getChildShapes().isEmpty()) {
+            m_connectors = setConnectorsMoveStart(ShapeControlUtils.getChildConnectorWithinShape(getShape()).values(), x, y);
+        }
     }
 
     private Collection<WiresConnector> setConnectorsMoveStart(Collection<WiresConnector> connectors, double x, double y) {
-        if (!connectors.isEmpty()) {
+        if (connectors != null && !connectors.isEmpty()) {
             for (WiresConnector connector : connectors) {
                 connector.getWiresConnectorHandler().getControl().onMoveStart(x, y);
             }

--- a/src/main/java/com/ait/lienzo/client/core/util/Geometry.java
+++ b/src/main/java/com/ait/lienzo/client/core/util/Geometry.java
@@ -1063,7 +1063,7 @@ public final class Geometry
         return arcIntersectPoints;
     }
 
-    private static final boolean intersectPointWithinBounding(final Point2D p, final Point2D a0, final Point2D a1)
+    public static final boolean intersectPointWithinBounding(final Point2D p, final Point2D a0, final Point2D a1)
     {
         boolean withinX = false;
 


### PR DESCRIPTION
Now the connector control points as a child of a shape has its position updated when the parent changes position.

Related PRs:
https://github.com/kiegroup/lienzo-tests/pull/28
https://github.com/kiegroup/kie-wb-common/pull/1863

@romartin 
@LuboTerifaj 
@hasys 