### PR TITLE
[7.7.x] RHPAM-1343: Stunner - Setter was not setting the field

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/config/LienzoCore.java
+++ b/src/main/java/com/ait/lienzo/client/core/config/LienzoCore.java
@@ -523,8 +523,8 @@ public final class LienzoCore
         return m_hidpiEnabled;
     }
 
-    public boolean setHidpiEnabled(boolean hidpiEnabled) {
-        return m_hidpiEnabled;
+    public boolean setHidpiEnabled(final boolean hidpiEnabled) {
+        return m_hidpiEnabled = hidpiEnabled;
     }
 
     private final boolean examineNativeLineDashSupported()


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHPAM-1343
(cherry picked from commit 3808bdc4cb84a5d56a2320f3fdaa9ef686dcf05f)