### PR TITLE
JBPM-6883 Stunner - can't move with bend points - setting drag bounds

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresConnector.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresConnector.java
@@ -231,7 +231,7 @@ public class WiresConnector
 
     public IControlHandleList getPointHandles()
     {
-        if (m_pointHandles == null)
+        if (m_pointHandles == null || m_pointHandles.isEmpty())
         {
             m_pointHandles = m_line.getControlHandles(POINT).get(POINT);
         }


### PR DESCRIPTION
Now it is now possible to move bend points of a connector outside of the canvas area.
It was necessary to set the drag bounds of the connector point handles.

@LuboTerifaj
@wmedvede (adding you to help on the review since @romartin is on PTO)

related: 
https://github.com/kiegroup/kie-wb-common/pull/2012
https://github.com/kiegroup/lienzo-tests/pull/39