### PR TITLE
JBPM-7715 (Stunner) - Align and distributions are shown incorrectly for the first alignment

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/AlignAndDistribute.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/AlignAndDistribute.java
@@ -199,8 +199,7 @@ public class AlignAndDistribute
         // only add if the group has not already been added
         if (null == handler)
         {
-            List<Attribute> attrs = null;
-            attrs = group.getBoundingBoxAttributes();
+            List<Attribute> attrs = group.getBoundingBoxAttributes();
             handler = new AlignAndDistributeControlImpl((IPrimitive<?>) group, this, m_alignmentCallback, attrs);
             m_shapes.put(uuid, handler);
         }

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/AlignAndDistribute.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/AlignAndDistribute.java
@@ -192,11 +192,6 @@ public class AlignAndDistribute
 
     public AlignAndDistributeControl addShape(IDrawable<?> group)
     {
-        return addShape(group, true);
-    }
-
-    public AlignAndDistributeControl addShape(IDrawable<?> group, boolean useChangeListener)
-    {
         final String uuid = group.uuid();
 
         AlignAndDistributeControl handler = m_shapes.get(uuid);
@@ -205,10 +200,7 @@ public class AlignAndDistribute
         if (null == handler)
         {
             List<Attribute> attrs = null;
-            if (useChangeListener)
-            {
-                attrs = group.getBoundingBoxAttributes();
-            }
+            attrs = group.getBoundingBoxAttributes();
             handler = new AlignAndDistributeControlImpl((IPrimitive<?>) group, this, m_alignmentCallback, attrs);
             m_shapes.put(uuid, handler);
         }

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresManager.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresManager.java
@@ -362,7 +362,7 @@ public final class WiresManager
 
     private AlignAndDistributeControl addToIndex(final WiresShape shape)
     {
-        return m_index.addShape(shape.getGroup(), false);
+        return m_index.addShape(shape.getGroup(), true);
     }
 
     private void removeFromIndex(final WiresShape shape)

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresManager.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresManager.java
@@ -362,7 +362,7 @@ public final class WiresManager
 
     private AlignAndDistributeControl addToIndex(final WiresShape shape)
     {
-        return m_index.addShape(shape.getGroup(), true);
+        return m_index.addShape(shape.getGroup());
     }
 
     private void removeFromIndex(final WiresShape shape)

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/AlignAndDistributeControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/AlignAndDistributeControlImpl.java
@@ -68,10 +68,6 @@ public class AlignAndDistributeControlImpl implements AlignAndDistributeControl
 
     private Flows.BooleanOp                                        m_tranOp;
 
-    private double                                                 m_leftOffset;
-
-    private double                                                 m_topOffset;
-
     public AlignAndDistributeControlImpl(IPrimitive<?> group, AlignAndDistribute alignAndDistribute, AlignAndDistribute.AlignAndDistributeMatchesCallback alignAndDistributeMatchesCallback, List<Attribute> attributes)
     {
         m_group = group;
@@ -129,7 +125,7 @@ public class AlignAndDistributeControlImpl implements AlignAndDistributeControl
         }
     }
 
-    private final AttributesChangedHandler ShapeAttributesChangedHandler = new AttributesChangedHandler()
+    protected final AttributesChangedHandler ShapeAttributesChangedHandler = new AttributesChangedHandler()
     {
         @Override
         public void onAttributesChanged(AttributesChangedEvent event)


### PR DESCRIPTION
https://issues.jboss.org/browse/JBPM-7715

Diagram's child element attribute changes weren't been listened to.
This fixes it.