### PR TITLE
JBPM-6920 (Stunner) - Align and distribute gets broken after an exception

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/AlignAndDistribute.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/AlignAndDistribute.java
@@ -209,10 +209,17 @@ public class AlignAndDistribute
             {
                 attrs = group.getBoundingBoxAttributes();
             }
-            handler = new AlignAndDistributeControlImpl((IPrimitive<?>) group, this, m_alignmentCallback, attrs);
+            handler = new AlignAndDistributeControlImpl((IPrimitive<?>) group, this, m_alignmentCallback);
             m_shapes.put(uuid, handler);
         }
         return handler;
+    }
+
+    public void refresh()
+    {
+        for(AlignAndDistributeControl handler : m_shapes.values()) {
+            handler.refresh();
+        }
     }
 
     public void removeShape(IDrawable<?> shape)
@@ -260,11 +267,12 @@ public class AlignAndDistribute
 
         LinkedList<AlignAndDistributeControl> bucket = index.get(rounded);
 
-        bucket.remove(handler);
+        if (bucket != null) {
+            bucket.remove(handler);
 
-        if (bucket.isEmpty())
-        {
-            index.remove(rounded);
+            if (bucket.isEmpty()) {
+                index.remove(rounded);
+            }
         }
     }
 
@@ -285,11 +293,12 @@ public class AlignAndDistribute
     {
         LinkedList<DistributionEntry> bucket = index.get(dist.getPoint());
 
-        bucket.remove(dist);
+        if (bucket != null) {
+            bucket.remove(dist);
 
-        if (bucket.isEmpty())
-        {
-            index.remove(dist.getPoint());
+            if (bucket.isEmpty()) {
+                index.remove(dist.getPoint());
+            }
         }
     }
 

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresContainer.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresContainer.java
@@ -194,10 +194,6 @@ public class WiresContainer
 
         shape.shapeMoved();
 
-        if (null != m_wiresManager && m_wiresManager.getAlignAndDistribute().isShapeIndexed(shape.uuid())) {
-            m_wiresManager.getAlignAndDistribute().getControlForShape(shape.uuid()).updateIndex();
-        }
-
         getLayoutHandler().requestLayout( this );
     }
 

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/AlignAndDistributeControl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/AlignAndDistributeControl.java
@@ -15,8 +15,6 @@ public interface AlignAndDistributeControl {
 
     void refresh();
 
-    void refresh( boolean transforms, boolean attributes );
-
     void dragStart();
 
     void dragEnd();
@@ -46,5 +44,4 @@ public interface AlignAndDistributeControl {
     void setIndexed(boolean indexed);
 
     void updateIndex();
-
 }

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresDockingControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresDockingControlImpl.java
@@ -261,7 +261,6 @@ public class WiresDockingControlImpl extends AbstractWiresParentPickerControl
                 shape.setLocation(new Point2D(event.getX() + (event.getWidth() * xRatio) - (shapeBox.getWidth() / 2),
                                               event.getY() + (event.getHeight() * yRatio) - (shapeBox.getHeight() / 2)));
                 shape.shapeMoved();
-                shape.getControl().getAlignAndDistributeControl().updateIndex();
             }
         }));
     }

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresShapeControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresShapeControlImpl.java
@@ -321,9 +321,6 @@ public class WiresShapeControlImpl
             getContainmentControl().reset();
         }
         parentPickerControl.reset();
-        if (null != m_alignAndDistributeControl) {
-            m_alignAndDistributeControl.updateIndex();
-        }
         getShape().shapeMoved();
         forEachConnectorControl(new Consumer<WiresConnectorControl>() {
             @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/JBPM-6920

Change in how the align and distribution indexation works. It used to
work by listening to changes in node attributes and updating it.
Most of the errors seemed to be caused due to missed updates due to a
change not been listened to.
To solve this, before a node drag event, all nodes and their values are
reindexed.

This also fixes other alignment problems:
https://issues.jboss.org/browse/JBPM-7668
https://issues.jboss.org/browse/JBPM-7715