### PR TITLE
DMN - Check whether the connector line has control points enabled

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresConnectorHandlerImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresConnectorHandlerImpl.java
@@ -173,6 +173,11 @@ public class WiresConnectorHandlerImpl implements WiresConnectorHandler {
 
     @Override
     public void onNodeMouseMove(final NodeMouseMoveEvent event) {
+        if (!getConnector().getLine().isControlPointShape()) {
+            //skipping in case the connector is not a control point shape
+            return;
+        }
+
         if (!isOverConnector(event.getX(), event.getY())) {
             destroyTransientControlHandle();
             return;


### PR DESCRIPTION
Check whether the connector line has control points enabled on WiresConnectorHandlerImpl to show the transient control handle - necessary for DMN.

related https://github.com/kiegroup/lienzo-tests/pull/48

@manstis 
