### PR TITLE
Fix possible OutOfRange exception

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/PolyLine.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/PolyLine.java
@@ -89,10 +89,13 @@ public class PolyLine extends AbstractDirectionalMultiPointShape<PolyLine>
         Point2DArray list = attr.getPoints();
 
         list = list.noAdjacentPoints();
-
         final int size = list.size();
-        final PathPartList path = getPathPartList();
 
+        if (0 == size) {
+            return false;
+        }
+
+        final PathPartList path = getPathPartList();
         final double headOffset = attr.getHeadOffset();
         final double tailOffset = attr.getTailOffset();
 


### PR DESCRIPTION
Hi @wmedvede, @romartin 

this is tests for fixed method which always returned true, as described here: https://github.com/wmedvede/lienzo-core/pull/1

I found out that `PolyLine#parse` method never returns `false` value.
 
Array newer will be null, but can be empty. Also some usages `WiresConnector#updateHeadTailForRefreshedConnector` of this method relay that if this method returns `true` it means there are some values and starts to use it's values:

**`WiresConnector#updateHeadTailForRefreshedConnector`**
```java
final boolean prepared = line.isPathPartListPrepared(c.getLine().getAttributes());

if (!prepared)
{
        return true;
}

Point2DArray points     = line.getPoint2DArray();
Point2D      p0         = points.get(0);
```

**`AbstractOffsetMultiPointShape#isPathPartListPrepared`**
```java
public boolean isPathPartListPrepared(final Attributes attr)
{
    if (getPathPartList().size() < 1)
    {
        return parse(attr);
    }

    return true;
}
```

tests can be found here: https://github.com/kiegroup/lienzo-tests/pull/50