### PR TITLE
RHPAM-1681: Focusing the lienzp panel in IE11 scrolls the parent one, if any, to left-top corner.

### DIFF
--- a/src/main/java/com/ait/lienzo/client/widget/LienzoPanel.java
+++ b/src/main/java/com/ait/lienzo/client/widget/LienzoPanel.java
@@ -32,6 +32,7 @@ import com.ait.lienzo.shared.core.types.IColor;
 import com.ait.tooling.common.api.java.util.function.Predicate;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Cursor;
 import com.google.gwt.user.client.Window;
@@ -504,6 +505,33 @@ public class LienzoPanel extends FocusPanel implements RequiresResize, ProvidesR
     {
         return getElement().getStyle().getBackgroundColor();
     }
+
+    @Override
+    public void setFocus(final boolean focused)
+    {
+        if (focused)
+        {
+            nativeFocus(getElement());
+        }
+        else
+        {
+            super.setFocus(false);
+        }
+    }
+
+    // IE11/Ege specific check - The "setActive" method does not cause scrolling on parent element, as setFocus does, and
+    // it results in the same behavior.
+    public static native void nativeFocus(final Element element)
+    /*-{
+        if (element.setActive)
+        {
+            element.setActive();
+        }
+        else
+        {
+            element.focus();
+        }
+    }-*/;
 
     /**
      * Returns the {@link Mediators} for this panels {@link Viewport}.


### PR DESCRIPTION
Hey @hasys @manstis 

Can you please check this quick fix for [RHPAM-1681](https://issues.jboss.org/browse/RHPAM-1681)

TBH I don't know how to correctly test this, even running a `GWTTestCase` (which runs a jetty etc)... it's an IE11 specific thing, so at much we can consider some integration test (selenium?), rather than a unit test... anyway if you have some other idea for fixing or testing this will be appreciated! :+1: 

PS: Tested on Chrome, FF, IE11 and Edge.

Relates to https://github.com/kiegroup/kie-wb-common/pull/2280

Thanks guys!! 