### PR TITLE
JBPM-8014 (Stunner) - Drag cancel causes an error

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/AlignAndDistribute.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/AlignAndDistribute.java
@@ -946,7 +946,7 @@ public class AlignAndDistribute
     {
         void call(AlignAndDistributeMatches matches);
 
-        void dragEnd();
+        void reset();
     }
 
     static class DefaultAlignAndDistributeMatchesCallback implements AlignAndDistributeMatchesCallback
@@ -1016,7 +1016,7 @@ public class AlignAndDistribute
         }
 
         @Override
-        public void dragEnd()
+        public void reset()
         {
             final Layer layer = getOverLayer();
 

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/AlignAndDistributeControl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/AlignAndDistributeControl.java
@@ -17,6 +17,8 @@ public interface AlignAndDistributeControl {
 
     void refresh( boolean transforms, boolean attributes );
 
+    void reset();
+
     void dragStart();
 
     void dragEnd();

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/AlignAndDistributeControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/AlignAndDistributeControlImpl.java
@@ -392,6 +392,27 @@ public class AlignAndDistributeControlImpl implements AlignAndDistributeControl
         return false;
     }
 
+    public void reset() {
+        if (m_isDragging) {
+            m_isDragging = false;
+
+            m_alignAndDistributeMatchesCallback.reset();
+
+            // We do not want the nested m_indexed shapes to impact the bounding box
+            // so remove them, they will be added once the index has been made.
+            List<ShapePair> pairs = new ArrayList<ShapePair>();
+            removeChildrenIfIndexed(m_group, pairs);
+
+            indexOn(m_group);
+
+            // re-add the children, index before it adds the next nested child
+            for (ShapePair pair : pairs) {
+                pair.parent.add(pair.child);
+                indexOn(pair.handler);
+            }
+        }
+    }
+
     @Override
     public void refresh()
     {
@@ -642,26 +663,7 @@ public class AlignAndDistributeControlImpl implements AlignAndDistributeControl
     @Override
     public void dragEnd()
     {
-        if (m_isDragging)
-        {
-            m_isDragging = false;
-
-            m_alignAndDistributeMatchesCallback.dragEnd();
-
-            // We do not want the nested m_indexed shapes to impact the bounding box
-            // so remove them, they will be added once the index has been made.
-            List<ShapePair> pairs = new ArrayList<ShapePair>();
-            removeChildrenIfIndexed(m_group, pairs);
-
-            indexOn(m_group);
-
-            // re-add the children, index before it adds the next nested child
-            for (ShapePair pair : pairs)
-            {
-                pair.parent.add(pair.child);
-                indexOn(pair.handler);
-            }
-        }
+        reset();
     }
 
     private void removeDragHandlerRegistrations()

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresShapeControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresShapeControlImpl.java
@@ -322,7 +322,7 @@ public class WiresShapeControlImpl
         }
         parentPickerControl.reset();
         if (null != m_alignAndDistributeControl) {
-            m_alignAndDistributeControl.updateIndex();
+            m_alignAndDistributeControl.reset();
         }
         getShape().shapeMoved();
         forEachConnectorControl(new Consumer<WiresConnectorControl>() {


### PR DESCRIPTION
https://issues.jboss.org/browse/JBPM-8014

The problem was AlignAndDistributeControlImpl.updateIndex() was called
mid drag. To fix this the same behavior that happened is now called
when the drag is cancelled.