### PR TITLE
DROOLS-3427: [DMN Designer] Connections between nodes throws an error if user moves the mouse too fast

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresManager.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresManager.java
@@ -45,7 +45,7 @@ import com.ait.tooling.nativetools.client.collection.NFastArrayList;
 import com.ait.tooling.nativetools.client.collection.NFastStringMap;
 import com.ait.tooling.nativetools.client.event.HandlerRegistrationManager;
 
-public final class WiresManager
+public class WiresManager
 {
 
     private static final NFastStringMap<WiresManager>        MANAGER_MAP           = new NFastStringMap<WiresManager>();


### PR DESCRIPTION
This allows `WiresManager` to be "mockeable".

This is part of https://github.com/kiegroup/kie-wb-common/pull/2355