### PR TITLE
JBPM-8341: Selected decoration doesn't applied to nodes for group selection

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/SelectionManager.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/SelectionManager.java
@@ -356,6 +356,8 @@ public class SelectionManager implements NodeMouseDoubleClickHandler, NodeMouseC
                     }
                     layer.draw();
                 }
+                getSelectedItems().selectShapes();
+
                 m_selectionCreationInProcess = false;
 
                 return false;
@@ -975,7 +977,7 @@ public class SelectionManager implements NodeMouseDoubleClickHandler, NodeMouseC
 
         public void notifyListener()
         {
-            m_selManager.m_selectionListener.onChanged(this);
+            selectShapes();
             m_changed.clear();
             if (isEmpty())
             {
@@ -985,6 +987,10 @@ public class SelectionManager implements NodeMouseDoubleClickHandler, NodeMouseC
                 clear();
             }
             m_layer.draw();
+        }
+
+        public void selectShapes() {
+            m_selManager.m_selectionListener.onChanged(this);
         }
     }
 


### PR DESCRIPTION
Hi @romartin, @treblereel,

I found small regression after https://github.com/kiegroup/lienzo-core/pull/86

When you do group selection - selection is created, but nodes are not decorated. You should click on selection one more time to change decoration to selected mode.

I already have a fix for it, but Jira is down, so I can't report an issue for it. So sending PR without issue. Tomorrow I have a PTO, so see you Monday.

CC @LuboTerifaj 

Tests for this PR https://github.com/kiegroup/lienzo-tests/pull/70