### PR TITLE
JBPM-8229 Stunner - Multi-line and long node name support

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/TextBoundsWrap.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/TextBoundsWrap.java
@@ -17,6 +17,7 @@
 package com.ait.lienzo.client.core.shape;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import com.ait.lienzo.client.core.Context2D;
 import com.ait.lienzo.client.core.types.BoundingBox;
@@ -29,7 +30,8 @@ import com.ait.lienzo.shared.core.types.TextUnit;
  */
 public class TextBoundsWrap extends TextNoWrap implements ITextWrapperWithBoundaries  {
 
-    private BoundingBox wrapBoundaries;
+    protected static final double      Y_OFFSET = 0.8;
+    private                BoundingBox wrapBoundaries;
 
     public TextBoundsWrap(final Text text) {
         this(text,
@@ -109,8 +111,7 @@ public class TextBoundsWrap extends TextNoWrap implements ITextWrapperWithBounda
 
     @Override
     public void drawString(final Context2D context,
-                           final Attributes attr,
-                           final IDrawString drawCommand) {
+                           final Attributes attr, final IDrawString drawCommand) {
         final String[] words = attr.getText().split("\\s");
 
         if (words.length < 1) {
@@ -125,43 +126,47 @@ public class TextBoundsWrap extends TextNoWrap implements ITextWrapperWithBounda
             } else {
                 lines.add(nextLine.toString());
                 nextLine.setLength(words[i].length());
-                nextLine.replace(0,
-                                 words[i].length(),
-                                 words[i]);
+                nextLine.replace(0, words[i].length(), words[i]);
             }
         }
         lines.add(nextLine.toString());
 
+        drawLines(context, drawCommand, lines, wrapBoundaries.getWidth());
+    }
+
+    protected void drawLines(Context2D context, IDrawString drawCommand, List<String> lines, double boundariesWidth)
+    {
         double xOffset = 0;
 
-        switch (textAlignSupplier.get()) {
-            case START:
-            case LEFT:
-                xOffset = 0;
-                break;
+        switch (textAlignSupplier.get())
+        {
+        case START:
+        case LEFT:
+            xOffset = 0;
+            break;
 
-            case CENTER:
-                xOffset = wrapBoundaries.getWidth() / 2;
-                break;
+        case CENTER:
+            xOffset = getWrapBoundaries().getWidth() / 2;
+            break;
 
-            case END:
-            case RIGHT:
-                xOffset = wrapBoundaries.getWidth();
-                break;
+        case END:
+        case RIGHT:
+            xOffset = getWrapBoundaries().getWidth();
+            break;
         }
-        double yOffset = 0.8;
 
-        for (int i = 0; i < lines.size(); i++) {
+        for (int i = 0; i < lines.size(); i++)
+        {
             String line = lines.get(i);
-            int toPad = (int) Math.round((wrapBoundaries.getWidth() - getBoundingBoxForString(line).getWidth()) / getBoundingBoxForString(" ").getWidth());
-            line = TextUtils.padString(line,
-                                       line.length() + toPad,
-                                       ' ',
-                                       textAlignSupplier.get());
-            drawCommand.draw(context,
-                             line,
-                             xOffset,
-                             i + yOffset);
+            if (line.length() == 0)
+            {
+                continue;
+            }
+            final int toPad = (int) Math
+                    .round((boundariesWidth - getBoundingBoxForString(line).getWidth()) / getBoundingBoxForString(" ")
+                            .getWidth());
+            line = TextUtils.padString(line, line.length() + toPad, ' ', textAlignSupplier.get());
+            drawCommand.draw(context, line, xOffset, i + Y_OFFSET);
         }
     }
 }

--- a/src/main/java/com/ait/lienzo/client/core/shape/TextLineBreakTruncateWrapper.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/TextLineBreakTruncateWrapper.java
@@ -59,7 +59,7 @@ import com.ait.lienzo.client.core.types.BoundingBox;
 
     private double getRemainingHeight(int numOfLines)
     {
-        return getWrapBoundaries().getHeight() - (Y_OFFSET * numOfLines) - Y_OFFSET * 2;
+        return getWrapBoundaries().getHeight() - (Y_OFFSET * numOfLines);
     }
 
     @Override public void drawString(final Context2D context, final Attributes attr, final IDrawString drawCommand)
@@ -78,7 +78,8 @@ import com.ait.lienzo.client.core.types.BoundingBox;
         for (int i = 0; i < words.length; i++)
         {
 
-            if (!hasVerticalSpace(lines.size(), getLineHeight(), getRemainingHeight(lines.size())) && !lines.isEmpty())
+            int lineIndex = lines.size() + 1;
+            if (!hasVerticalSpace(lineIndex, getLineHeight(), getRemainingHeight(lineIndex)) && !lines.isEmpty())
             {
                 String endWord = lines.get(lines.size() - 1);
                 String truncated =

--- a/src/main/java/com/ait/lienzo/client/core/shape/TextLineBreakTruncateWrapper.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/TextLineBreakTruncateWrapper.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ait.lienzo.client.core.shape;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.ait.lienzo.client.core.Context2D;
+import com.ait.lienzo.client.core.types.BoundingBox;tru
+
+/**
+ * ITextWrapper implementation that truncates text and appends "..." if there is no space left.
+ */
+@SuppressWarnings("Duplicates") public class TextLineBreakTruncateWrapper extends TextTruncateWrapper
+{
+
+    public static final String WHITESPACE_REGEX   = " |\\t";
+    public static final String LINEBREAK          = "\n";
+    public static final int    MAX_LENGHT_TO_WRAP = 10;
+
+    public TextLineBreakTruncateWrapper(final Text text, final BoundingBox wrapBoundaries)
+    {
+        super(text, wrapBoundaries);
+    }
+
+    private String[] splitWords(final String text)
+    {
+        return text.replaceAll(LINEBREAK, " " + LINEBREAK + " ").split(WHITESPACE_REGEX);
+    }
+
+    @Override protected double[] calculateWrapBoundaries()
+    {
+        final List<String> lines = getWrappedTextLines(textSupplier.get());
+        final double height = getHeightByLines(lines.size());
+
+        double maxWidth = 0;
+        for (String line : lines)
+        {
+            double lineWidth = getBoundingBoxForString(line).getWidth();
+            maxWidth = (lineWidth > maxWidth) ? lineWidth : maxWidth;
+        }
+
+        return new double[] { maxWidth, height };
+    }
+
+    private double getRemainingHeight(int numOfLines)
+    {
+        return getWrapBoundaries().getHeight() - (Y_OFFSET * numOfLines) - MARGIN;
+    }
+
+    @Override public void drawString(final Context2D context, final Attributes attr, final IDrawString drawCommand)
+    {
+        final List<String> lines = getWrappedTextLines(attr.getText());
+        drawLines(context, drawCommand, lines, getBoundingBox().getWidth());
+    }
+
+    private List<String> getWrappedTextLines(final String text)
+    {
+        final String[] words = splitWords(text);
+        final List<String> lines = new ArrayList<>();
+        final double boundariesWidth = getWrapBoundariesWidth();
+        final StringBuilder currentLine = new StringBuilder();
+
+        for (int i = 0; i < words.length; i++)
+        {
+
+            if (!hasVerticalSpace(lines.size(), getLineHeight(), getRemainingHeight(lines.size())))
+            {
+                String endWord = lines.get(lines.size() - 1);
+                String truncated =
+                        (endWord.length() > 4 ? endWord.substring(0, endWord.length() - 4) : endWord) + "...";
+                lines.remove(lines.size() - 1);
+                lines.add(truncated);
+                break;
+            }
+
+            final String currentWord = words[i] + ((i + 1 < words.length) ? " " : "");
+            if (currentWord.contains(LINEBREAK))
+            {
+                flushLine(lines, currentLine);
+                continue;
+            }
+
+            if (!hasHorizontalSpaceToDraw(currentLine.toString(), currentWord, boundariesWidth))
+            {
+                //find the currentWord max char index that fits the boundariesWidth
+                final int splitCharIndex = getSplitCharIndexToFitWidth(boundariesWidth, currentLine.toString(),
+                        currentWord);
+
+                //spliting the word to fit the boundaries width
+                String remainingWord = currentWord.substring(splitCharIndex);
+                String truncated = currentWord.substring(0, splitCharIndex);
+
+                //handle splited word in case it is short, breaking to the next line
+                if (remainingWord.length() < MAX_LENGHT_TO_WRAP && currentLine.length() > 0)
+                {
+                    truncated = "";
+                    remainingWord = currentWord;
+                }
+
+                currentLine.append(truncated);
+                flushLine(lines, currentLine);
+
+                //reprocess the remainingWord (i--)
+                words[i--] = remainingWord;
+                continue;
+            }
+
+            currentLine.append(currentWord);
+
+            //handle last line
+            if (i == words.length - 1)
+            {
+                lines.add(currentLine.toString());
+                break;
+            }
+        }
+        return lines;
+    }
+
+    private int getSplitCharIndexToFitWidth(double boundariesWidth, String currentLine, String currentWord)
+    {
+        int remainingCharIndex = 0;
+        while (hasHorizontalSpaceToDraw(currentLine, currentWord.substring(0, ++remainingCharIndex), boundariesWidth))
+        {
+        }
+        return remainingCharIndex;
+    }
+
+    private void flushLine(final List<String> lines, final StringBuilder currentLine)
+    {
+        lines.add(currentLine.toString());
+        currentLine.setLength(0);
+    }
+}

--- a/src/main/java/com/ait/lienzo/client/core/shape/TextLineBreakTruncateWrapper.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/TextLineBreakTruncateWrapper.java
@@ -59,7 +59,7 @@ import com.ait.lienzo.client.core.types.BoundingBox;
 
     private double getRemainingHeight(int numOfLines)
     {
-        return getWrapBoundaries().getHeight() - (Y_OFFSET * numOfLines);
+        return getWrapBoundaries().getHeight() - (Y_OFFSET * numOfLines) - Y_OFFSET * 2;
     }
 
     @Override public void drawString(final Context2D context, final Attributes attr, final IDrawString drawCommand)

--- a/src/main/java/com/ait/lienzo/client/core/shape/TextLineBreakTruncateWrapper.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/TextLineBreakTruncateWrapper.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.ait.lienzo.client.core.Context2D;
-import com.ait.lienzo.client.core.types.BoundingBox;tru
+import com.ait.lienzo.client.core.types.BoundingBox;
 
 /**
  * ITextWrapper implementation that truncates text and appends "..." if there is no space left.
@@ -59,7 +59,7 @@ import com.ait.lienzo.client.core.types.BoundingBox;tru
 
     private double getRemainingHeight(int numOfLines)
     {
-        return getWrapBoundaries().getHeight() - (Y_OFFSET * numOfLines) - MARGIN;
+        return getWrapBoundaries().getHeight() - (Y_OFFSET * numOfLines);
     }
 
     @Override public void drawString(final Context2D context, final Attributes attr, final IDrawString drawCommand)
@@ -78,17 +78,18 @@ import com.ait.lienzo.client.core.types.BoundingBox;tru
         for (int i = 0; i < words.length; i++)
         {
 
-            if (!hasVerticalSpace(lines.size(), getLineHeight(), getRemainingHeight(lines.size())))
+            if (!hasVerticalSpace(lines.size(), getLineHeight(), getRemainingHeight(lines.size())) && !lines.isEmpty())
             {
                 String endWord = lines.get(lines.size() - 1);
                 String truncated =
-                        (endWord.length() > 4 ? endWord.substring(0, endWord.length() - 4) : endWord) + "...";
+                        (endWord.length() > 3 ? endWord.substring(0, endWord.length() - 4) : endWord) + "...";
                 lines.remove(lines.size() - 1);
                 lines.add(truncated);
                 break;
             }
 
-            final String currentWord = words[i] + ((i + 1 < words.length) ? " " : "");
+            //set current world + whitespace if applicable
+            final String currentWord = words[i];
             if (currentWord.contains(LINEBREAK))
             {
                 flushLine(lines, currentLine);
@@ -120,7 +121,7 @@ import com.ait.lienzo.client.core.types.BoundingBox;tru
                 continue;
             }
 
-            currentLine.append(currentWord);
+            currentLine.append(currentWord + ((i + 1 < words.length && !" ".equals(words[i])) ? " " : ""));
 
             //handle last line
             if (i == words.length - 1)

--- a/src/main/java/com/ait/lienzo/client/core/shape/TextTruncateWrapper.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/TextTruncateWrapper.java
@@ -27,7 +27,9 @@ import com.ait.lienzo.client.core.types.BoundingBox;
 @SuppressWarnings("Duplicates")
 public class TextTruncateWrapper extends TextNoWrap implements ITextWrapperWithBoundaries
 {
-    private static final double     Y_OFFSET           = 0.8;
+    private static final double Y_OFFSET         = 0.8;
+    public static final  String WHITESPACE_REGEX = " +|\\t+";
+    public static final String LINEBREAK = "\n";
 
     private BoundingBox             m_wrapBoundaries;
 
@@ -63,9 +65,14 @@ public class TextTruncateWrapper extends TextNoWrap implements ITextWrapperWithB
         return m_wrapBoundaries.getWidth() - m_margin;
     }
 
+    private String[] splitWords(final String text)
+    {
+        return text.replaceAll(LINEBREAK, " " + LINEBREAK + " ").split(WHITESPACE_REGEX);
+    }
+
     private double[] calculateWrapBoundaries()
     {
-        final String[] words = textSupplier.get().split("\\s");
+        final String[] words = splitWords(textSupplier.get());
         if (words.length < 1)
         {
             return new double[]{m_wrapBoundaries.getX(), m_wrapBoundaries.getY()};
@@ -78,17 +85,26 @@ public class TextTruncateWrapper extends TextNoWrap implements ITextWrapperWithB
         int numOfLines = 1;
         for (int i = 1; i < words.length; i++)
         {
-            width = getBoundingBoxForString(nextLine + " " + words[i]).getWidth();
+            final String currentWord = words[i];
+            if (currentWord.equals(LINEBREAK))
+            {
+                final String nextWord = words[i + 1];
+                if (LINEBREAK.equals(nextWord))
+                {
+                    numOfLines++;
+                }
+                continue;
+            }
+
+            width = getBoundingBoxForString(nextLine + " " + currentWord).getWidth();
             if (width <= wrapWidth)
             {
-                nextLine.append(" ").append(words[i]);
+                nextLine.append(" ").append(currentWord);
             }
             else
             {
-                nextLine.setLength(words[i].length());
-                nextLine.replace(0,
-                                 words[i].length(),
-                                 words[i]);
+                nextLine.setLength(currentWord.length());
+                nextLine.replace(0, currentWord.length(), currentWord);
                 numOfLines++;
             }
         }
@@ -123,7 +139,7 @@ public class TextTruncateWrapper extends TextNoWrap implements ITextWrapperWithB
                            final Attributes attr,
                            final IDrawString drawCommand)
     {
-        final String[] words = attr.getText().split("\\s");
+        final String[] words = splitWords(attr.getText());
 
         if (words.length < 1)
         {
@@ -138,19 +154,32 @@ public class TextTruncateWrapper extends TextNoWrap implements ITextWrapperWithB
         for (int i = 0; i < words.length; i++)
         {
             currentWord = words[i];
+            final String nextWord = (words.length - 1 > i) ? words[i + 1] : null;
+            if (currentWord.contains(LINEBREAK))
+            {
+                if (LINEBREAK.equals(nextWord))
+                {
+                    //adding empty line
+                    lines.add("");
+                }
+                continue;
+            }
 
             if (hasHorizontalSpaceToDraw(currentLine.toString(), currentWord, boundariesWidth))
             {
-                if (i + 1 < words.length
+                if (!LINEBREAK.equals(nextWord) && i + 1 < words.length
                         && getBoundingBoxForString(currentLine + currentWord + " " + words[i + 1]).getWidth() <= boundariesWidth)
                 {
-                    currentLine.append(currentWord).append(" ").append(words[i + 1]);
+                    currentLine.append(currentWord).append(" ").append(nextWord);
                     i++;
 
                     int j = i + 1;
                     while (j < words.length
                             && getBoundingBoxForString(currentLine + " " + words[j]).getWidth() <= boundariesWidth)
                     {
+                        if (words[j].contains(LINEBREAK)) {
+                            break;
+                        }
 
                         currentLine.append(" ").append(words[j]);
                         i++;

--- a/src/main/java/com/ait/lienzo/client/core/shape/TextTruncateWrapper.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/TextTruncateWrapper.java
@@ -24,16 +24,12 @@ import com.ait.lienzo.client.core.types.BoundingBox;
 /**
  * ITextWrapper implementation that truncates text and appends "..." if there is no space left.
  */
-@SuppressWarnings("Duplicates")
-public class TextTruncateWrapper extends TextNoWrap implements ITextWrapperWithBoundaries
+@SuppressWarnings("Duplicates") public class TextTruncateWrapper extends TextBoundsWrap
+        implements ITextWrapperWithBoundaries
 {
-    private static final double Y_OFFSET         = 0.8;
-    public static final  String WHITESPACE_REGEX = " +|\\t+";
-    public static final String LINEBREAK = "\n";
-
     private BoundingBox             m_wrapBoundaries;
 
-    private static final double     m_margin           = 20;
+    protected static final double MARGIN = 20;
 
     public TextTruncateWrapper(final Text text,
                                final BoundingBox wrapBoundaries)
@@ -60,19 +56,14 @@ public class TextTruncateWrapper extends TextNoWrap implements ITextWrapperWithB
         return new BoundingBox().addX(0).addX(m_wrapBoundaries.getWidth()).addY(0).addY(boundaries[1]);
     }
 
-    private double getWrapBoundariesWidth()
+    protected double getWrapBoundariesWidth()
     {
-        return m_wrapBoundaries.getWidth() - m_margin;
+        return m_wrapBoundaries.getWidth() - MARGIN;
     }
 
-    private String[] splitWords(final String text)
+    protected double[] calculateWrapBoundaries()
     {
-        return text.replaceAll(LINEBREAK, " " + LINEBREAK + " ").split(WHITESPACE_REGEX);
-    }
-
-    private double[] calculateWrapBoundaries()
-    {
-        final String[] words = splitWords(textSupplier.get());
+        final String[] words = textSupplier.get().split("\\s");
         if (words.length < 1)
         {
             return new double[]{m_wrapBoundaries.getX(), m_wrapBoundaries.getY()};
@@ -85,30 +76,25 @@ public class TextTruncateWrapper extends TextNoWrap implements ITextWrapperWithB
         int numOfLines = 1;
         for (int i = 1; i < words.length; i++)
         {
-            final String currentWord = words[i];
-            if (currentWord.equals(LINEBREAK))
-            {
-                final String nextWord = words[i + 1];
-                if (LINEBREAK.equals(nextWord))
-                {
-                    numOfLines++;
-                }
-                continue;
-            }
-
-            width = getBoundingBoxForString(nextLine + " " + currentWord).getWidth();
+            width = getBoundingBoxForString(nextLine + " " + words[i]).getWidth();
             if (width <= wrapWidth)
             {
-                nextLine.append(" ").append(currentWord);
+                nextLine.append(" ").append(words[i]);
             }
             else
             {
-                nextLine.setLength(currentWord.length());
-                nextLine.replace(0, currentWord.length(), currentWord);
+                nextLine.setLength(words[i].length());
+                nextLine.replace(0, words[i].length(), words[i]);
                 numOfLines++;
             }
         }
 
+        final double height = getHeightByLines(numOfLines);
+        return new double[] { width, height };
+    }
+
+    protected double getHeightByLines(int numOfLines)
+    {
         final double lineHeight = getLineHeight();
 
         while (!hasVerticalSpace(numOfLines, lineHeight, m_wrapBoundaries.getHeight() - (Y_OFFSET * numOfLines))
@@ -117,19 +103,17 @@ public class TextTruncateWrapper extends TextNoWrap implements ITextWrapperWithB
             numOfLines--;
         }
 
-        final double height = lineHeight * numOfLines;
-
-        return new double[]{width, height};
+        return lineHeight * numOfLines;
     }
 
-    private boolean hasVerticalSpace(final int lineIndex,
+    protected boolean hasVerticalSpace(final int lineIndex,
                                      final double lineHeight,
                                      final double availableHeight)
     {
         return lineHeight * (lineIndex + Y_OFFSET) <= availableHeight;
     }
 
-    private double getLineHeight()
+    protected double getLineHeight()
     {
         return getBoundingBoxForString("Mg").getHeight();
     }
@@ -139,7 +123,7 @@ public class TextTruncateWrapper extends TextNoWrap implements ITextWrapperWithB
                            final Attributes attr,
                            final IDrawString drawCommand)
     {
-        final String[] words = splitWords(attr.getText());
+        final String[] words = attr.getText().split("\\s");
 
         if (words.length < 1)
         {
@@ -154,32 +138,19 @@ public class TextTruncateWrapper extends TextNoWrap implements ITextWrapperWithB
         for (int i = 0; i < words.length; i++)
         {
             currentWord = words[i];
-            final String nextWord = (words.length - 1 > i) ? words[i + 1] : null;
-            if (currentWord.contains(LINEBREAK))
-            {
-                if (LINEBREAK.equals(nextWord))
-                {
-                    //adding empty line
-                    lines.add("");
-                }
-                continue;
-            }
 
             if (hasHorizontalSpaceToDraw(currentLine.toString(), currentWord, boundariesWidth))
             {
-                if (!LINEBREAK.equals(nextWord) && i + 1 < words.length
+                if (i + 1 < words.length
                         && getBoundingBoxForString(currentLine + currentWord + " " + words[i + 1]).getWidth() <= boundariesWidth)
                 {
-                    currentLine.append(currentWord).append(" ").append(nextWord);
+                    currentLine.append(currentWord).append(" ").append(words[i + 1]);
                     i++;
 
                     int j = i + 1;
                     while (j < words.length
                             && getBoundingBoxForString(currentLine + " " + words[j]).getWidth() <= boundariesWidth)
                     {
-                        if (words[j].contains(LINEBREAK)) {
-                            break;
-                        }
 
                         currentLine.append(" ").append(words[j]);
                         i++;
@@ -259,45 +230,10 @@ public class TextTruncateWrapper extends TextNoWrap implements ITextWrapperWithB
             }
         }
 
-        double xOffset = 0;
-
-        switch (textAlignSupplier.get())
-        {
-            case START:
-            case LEFT:
-                xOffset = 0;
-                break;
-
-            case CENTER:
-                xOffset = m_wrapBoundaries.getWidth() / 2;
-                break;
-
-            case END:
-            case RIGHT:
-                xOffset = m_wrapBoundaries.getWidth();
-                break;
-        }
-
-        for (int i = 0; i < lines.size(); i++)
-        {
-            String line = lines.get(i);
-            if (line.length() == 0)
-            {
-                continue;
-            }
-            final int toPad = (int) Math.round((boundariesWidth - getBoundingBoxForString(line).getWidth()) / getBoundingBoxForString(" ").getWidth());
-            line = TextUtils.padString(line,
-                                       line.length() + toPad,
-                                       ' ',
-                                       textAlignSupplier.get());
-            drawCommand.draw(context,
-                             line,
-                             xOffset,
-                             i + Y_OFFSET);
-        }
+        drawLines(context, drawCommand, lines, boundariesWidth);
     }
 
-    private boolean hasHorizontalSpaceToDraw(final String currentLine,
+    protected boolean hasHorizontalSpaceToDraw(final String currentLine,
                                              final String currentWord,
                                              final double boundariesWidth)
     {


### PR DESCRIPTION
Adding support to linebreak on the `TextTruncateWrapper`.  
This is necessary on Stunner BPMN to support multiline on the node labels.

Related
https://github.com/kiegroup/lienzo-tests/pull/71
https://github.com/kiegroup/kie-wb-common/pull/2536

@romartin 
@LuboTerifaj 
@danielzhe 