### PR TITLE
BXMSPROD-494 allow GA build on windows machine

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,9 +6,10 @@ jobs:
   build-chain:
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         java-version: [8, 11]
       fail-fast: true
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     name: Maven Build
     steps:
       - name: Set up JDK

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,6 +19,15 @@ jobs:
       - name: Install takari
         run: |
           gci env:* | sort-object name
+          echo "TESTING"
+          echo "TESTING1"
+          echo %M2_HOME%
+          echo "TESTING1_B"
+          echo $M2_HOME
+          echo "TESTING2"
+          echo "M2_HOME1: "+%M2_HOME%
+          echo "M2_HOME2: "+$M2_HOME
+          echo "END TESTING"
           (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "C:\ProgramData\chocolatey\lib\maven\apache-maven-3.6.3\lib\ext\takari-local-repository-0.11.3.jar")
           (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar", "C:\ProgramData\chocolatey\lib\maven\apache-maven-3.6.3\lib\ext\takari-filemanager-0.8.3.jar")
           (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar", "C:\ProgramData\chocolatey\lib\maven\apache-maven-3.6.3\lib\ext\takari-smart-builder-0.6.1.jar")

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,9 +19,6 @@ jobs:
       - name: Install takari
         run: |
           gci env:* | sort-object name
-          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "$M2_HOME/lib/ext/takari-local-repository-0.11.3.jar")
-          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar", "$M2_HOME/lib/ext/takari-filemanager-0.8.3.jar")
-          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar", "$M2_HOME/lib/ext/takari-smart-builder-0.6.1.jar")
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
         uses: kiegroup/github-action-build-chain@v1.4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,20 +18,10 @@ jobs:
           java-version: ${{ matrix.java-version }}
       - name: Install takari
         run: |
-          gci env:* | sort-object name
-          echo "TESTING"
-          echo $Env:PATH
-          echo "TESTING2"
-          echo $Env:M2_HOME
-          echo "TESTING3"
-          echo "PATH"+$Env:PATH
-          echo "TESTING4"
-          echo "M2_HOME"+$Env:M2_HOME
-          echo "END TESTING"
-          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "C:\ProgramData\chocolatey\lib\maven\apache-maven-3.6.3\lib\ext\takari-local-repository-0.11.3.jar")
-          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar", "C:\ProgramData\chocolatey\lib\maven\apache-maven-3.6.3\lib\ext\takari-filemanager-0.8.3.jar")
-          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar", "C:\ProgramData\chocolatey\lib\maven\apache-maven-3.6.3\lib\ext\takari-smart-builder-0.6.1.jar")
-          dir C:\ProgramData\chocolatey\lib\maven\apache-maven-3.6.3\lib\ext\
+          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "$Env:M2_HOME\lib\ext\takari-local-repository-0.11.3.jar")
+          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar", "$Env:M2_HOME\lib\ext\takari-filemanager-0.8.3.jar")
+          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar", "$Env:M2_HOME\lib\ext\takari-smart-builder-0.6.1.jar")
+          dir $Env:M2_HOME\lib\ext\
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
         uses: kiegroup/github-action-build-chain@v1.4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,9 +18,9 @@ jobs:
           java-version: ${{ matrix.java-version }}
       - name: Install takari
         run: |
-          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "$M2_HOME/lib/ext")
-          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar", "$M2_HOME/lib/ext")
-          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar", "$M2_HOME/lib/ext")
+          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "$M2_HOME/lib/ext/takari-local-repository-0.11.3.jar")
+          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar", "$M2_HOME/lib/ext/takari-filemanager-0.8.3.jar")
+          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar", "$M2_HOME/lib/ext/takari-smart-builder-0.6.1.jar")
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
         uses: kiegroup/github-action-build-chain@v1.4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,6 +18,7 @@ jobs:
           java-version: ${{ matrix.java-version }}
       - name: Install takari
         run: |
+          SET
           echo %M2_HOME%
           echo "^^^^^"
           (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "$M2_HOME/lib/ext/takari-local-repository-0.11.3.jar")

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,9 +16,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java-version }}
-      - name: Check wget
-        run: |
-          wget -h
       - name: Install takari
         run: |
           $client = New-Object System.Net.WebClient

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,10 +18,7 @@ jobs:
           java-version: ${{ matrix.java-version }}
       - name: Install takari
         run: |
-          SET M2_HOME
-          SET M2
-          echo %M2_HOME%
-          echo "^^^^^"
+          gci env:* | sort-object name
           (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "$M2_HOME/lib/ext/takari-local-repository-0.11.3.jar")
           (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar", "$M2_HOME/lib/ext/takari-filemanager-0.8.3.jar")
           (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar", "$M2_HOME/lib/ext/takari-smart-builder-0.6.1.jar")

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Install takari
         run: |
           gci env:* | sort-object name
-          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "$M2_HOME\lib\ext\takari-local-repository-0.11.3.jar")
-          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar", "$M2_HOME\lib\ext\takari-filemanager-0.8.3.jar")
-          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar", "$M2_HOME\lib\ext\takari-smart-builder-0.6.1.jar")
+          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "C:\ProgramData\chocolatey\lib\maven\apache-maven-3.6.3\lib\ext\takari-local-repository-0.11.3.jar")
+          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar", "C:\ProgramData\chocolatey\lib\maven\apache-maven-3.6.3\lib\ext\takari-filemanager-0.8.3.jar")
+          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar", "C:\ProgramData\chocolatey\lib\maven\apache-maven-3.6.3\lib\ext\takari-smart-builder-0.6.1.jar")
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
         uses: kiegroup/github-action-build-chain@v1.4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,8 +6,8 @@ jobs:
   build-chain:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        java-version: [8, 11]
+        os: [windows-latest]
+        java-version: [8]
       fail-fast: true
     runs-on: ${{ matrix.os }}
     name: Maven Build
@@ -21,9 +21,10 @@ jobs:
           wget -h
       - name: Install takari
         run: |
-          wget -P $M2_HOME/lib/ext https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar
-          wget -P $M2_HOME/lib/ext https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar
-          wget -P $M2_HOME/lib/ext https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar
+          $client = New-Object System.Net.WebClient
+          $client.DownloadFile(https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar, $M2_HOME/lib/ext)
+          $client.DownloadFile(https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar, $M2_HOME/lib/ext)
+          $client.DownloadFile(https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar, $M2_HOME/lib/ext)
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
         uses: kiegroup/github-action-build-chain@v1.4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,8 @@ jobs:
           java-version: ${{ matrix.java-version }}
       - name: Install takari
         run: |
-          SET
+          SET M2_HOME
+          SET M2
           echo %M2_HOME%
           echo "^^^^^"
           (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "$M2_HOME/lib/ext/takari-local-repository-0.11.3.jar")

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,9 +19,10 @@ jobs:
       - name: Install takari
         run: |
           $client = New-Object System.Net.WebClient
-          $client.DownloadFile(https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar, $M2_HOME/lib/ext)
-          $client.DownloadFile(https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar, $M2_HOME/lib/ext)
-          $client.DownloadFile(https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar, $M2_HOME/lib/ext)
+          $client.DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "$M2_HOME/lib/ext")
+          $client.DownloadFile("https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar", "$M2_HOME/lib/ext")
+          $client.DownloadFile("https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar", "$M2_HOME/lib/ext")
+          echo $M2_HOME
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
         uses: kiegroup/github-action-build-chain@v1.4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,17 +20,18 @@ jobs:
         run: |
           gci env:* | sort-object name
           echo "TESTING"
-          echo "TESTING1"
-          echo %M2_HOME%
-          echo "TESTING1_B"
-          echo $M2_HOME
+          echo $Env:PATH
           echo "TESTING2"
-          echo "M2_HOME1: "+%M2_HOME%
-          echo "M2_HOME2: "+$M2_HOME
+          echo $Env:M2_HOME
+          echo "TESTING3"
+          echo "PATH"+$Env:PATH
+          echo "TESTING4"
+          echo "M2_HOME"+$Env:M2_HOME
           echo "END TESTING"
           (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "C:\ProgramData\chocolatey\lib\maven\apache-maven-3.6.3\lib\ext\takari-local-repository-0.11.3.jar")
           (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar", "C:\ProgramData\chocolatey\lib\maven\apache-maven-3.6.3\lib\ext\takari-filemanager-0.8.3.jar")
           (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar", "C:\ProgramData\chocolatey\lib\maven\apache-maven-3.6.3\lib\ext\takari-smart-builder-0.6.1.jar")
+          dir C:\ProgramData\chocolatey\lib\maven\apache-maven-3.6.3\lib\ext\
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
         uses: kiegroup/github-action-build-chain@v1.4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,6 +18,8 @@ jobs:
           java-version: ${{ matrix.java-version }}
       - name: Install takari
         run: |
+          echo %M2_HOME%
+          echo "^^^^^"
           (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "$M2_HOME/lib/ext/takari-local-repository-0.11.3.jar")
           (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar", "$M2_HOME/lib/ext/takari-filemanager-0.8.3.jar")
           (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar", "$M2_HOME/lib/ext/takari-smart-builder-0.6.1.jar")

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Install takari
         run: |
           gci env:* | sort-object name
+          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "$M2_HOME\lib\ext\takari-local-repository-0.11.3.jar")
+          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar", "$M2_HOME\lib\ext\takari-filemanager-0.8.3.jar")
+          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar", "$M2_HOME\lib\ext\takari-smart-builder-0.6.1.jar")
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
         uses: kiegroup/github-action-build-chain@v1.4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,6 +16,9 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java-version }}
+      - name: Check wget
+        run: |
+          wget -h
       - name: Install takari
         run: |
           wget -P $M2_HOME/lib/ext https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,11 +18,9 @@ jobs:
           java-version: ${{ matrix.java-version }}
       - name: Install takari
         run: |
-          $client = New-Object System.Net.WebClient
-          $client.DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "$M2_HOME/lib/ext")
-          $client.DownloadFile("https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar", "$M2_HOME/lib/ext")
-          $client.DownloadFile("https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar", "$M2_HOME/lib/ext")
-          echo $M2_HOME
+          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "$M2_HOME/lib/ext")
+          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar", "$M2_HOME/lib/ext")
+          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar", "$M2_HOME/lib/ext")
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
         uses: kiegroup/github-action-build-chain@v1.4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,8 +6,8 @@ jobs:
   build-chain:
     strategy:
       matrix:
-        os: [windows-latest]
-        java-version: [8]
+        os: [ubuntu-latest, windows-latest]
+        java-version: [8, 11]
       fail-fast: true
     runs-on: ${{ matrix.os }}
     name: Maven Build
@@ -16,12 +16,18 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java-version }}
-      - name: Install takari
+      - name: Install takari (non-windows)
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: |
+          wget -P $M2_HOME/lib/ext https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar
+          wget -P $M2_HOME/lib/ext https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar
+          wget -P $M2_HOME/lib/ext https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar
+      - name: Install takari (windows)
+        if: ${{ matrix.os == 'windows-latest' }}
         run: |
           (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "$Env:M2_HOME\lib\ext\takari-local-repository-0.11.3.jar")
           (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar", "$Env:M2_HOME\lib\ext\takari-filemanager-0.8.3.jar")
           (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar", "$Env:M2_HOME\lib\ext\takari-smart-builder-0.6.1.jar")
-          dir $Env:M2_HOME\lib\ext\
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
         uses: kiegroup/github-action-build-chain@v1.4


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-494

related to

https://github.com/kiegroup/lienzo-core/pull/133
https://github.com/kiegroup/lienzo-tests/pull/108
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1471
https://github.com/kiegroup/kie-soup/pull/158
https://github.com/kiegroup/appformer/pull/1054
https://github.com/kiegroup/droolsjbpm-knowledge/pull/465
https://github.com/kiegroup/drools/pull/3116
https://github.com/kiegroup/optaplanner/pull/940
https://github.com/kiegroup/jbpm/pull/1758
https://github.com/kiegroup/kie-jpmml-integration/pull/43
https://github.com/kiegroup/droolsjbpm-integration/pull/2243
https://github.com/kiegroup/openshift-drools-hacep/pull/100
https://github.com/kiegroup/droolsjbpm-tools/pull/118
https://github.com/kiegroup/kie-uberfire-extensions/pull/106
https://github.com/kiegroup/kie-wb-playground/pull/97
https://github.com/kiegroup/kie-wb-common/pull/3423
https://github.com/kiegroup/drools-wb/pull/1423
https://github.com/kiegroup/optaplanner-wb/pull/381
https://github.com/kiegroup/jbpm-designer/pull/891
https://github.com/kiegroup/jbpm-wb/pull/1461
https://github.com/kiegroup/jbpm-work-items/pull/153
https://github.com/kiegroup/kie-docs/pull/2849
https://github.com/kiegroup/optaweb-employee-rostering/pull/498
https://github.com/kiegroup/optaweb-vehicle-routing/pull/367
https://github.com/kiegroup/kie-wb-distributions/pull/1062